### PR TITLE
chore: respect xdg config on darwin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+# to test operations on linux
+services:
+  bmm-dev:
+    image: rust:1.85-slim-bullseye
+    platform: linux/amd64
+    volumes:
+      - .:/usr/src/app
+    working_dir: /usr/src/app
+    command: sleep infinity

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -53,6 +53,7 @@ impl AppError {
     pub fn code(&self) -> Option<u16> {
         match self {
             AppError::CouldntGetDataDirectory(e) => match e {
+                #[cfg(target_family = "unix")]
                 DataDirError::XDGDataHomeNotAbsolute => None,
                 DataDirError::CouldntGetDataDir => Some(100),
             },

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,13 +5,14 @@ use crate::cli::{
 };
 use crate::persistence::DBError;
 use crate::tui::AppTuiError;
+use crate::utils::DataDirError;
 use std::io::Error as IOError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum AppError {
     // data related
-    #[error("couldn't get your data directory, trying passing a db path manually")]
-    CouldntGetDataDirectory,
+    #[error(transparent)]
+    CouldntGetDataDirectory(DataDirError),
     #[error("could not create data directory: {0}")]
     CouldntCreateDataDirectory(IOError),
     #[error("couldn't initialize bmm's database: {0}")]
@@ -51,7 +52,10 @@ pub enum AppError {
 impl AppError {
     pub fn code(&self) -> Option<u16> {
         match self {
-            AppError::CouldntGetDataDirectory => Some(100),
+            AppError::CouldntGetDataDirectory(e) => match e {
+                DataDirError::XDGDataHomeNotAbsolute => None,
+                DataDirError::CouldntGetDataDir => Some(100),
+            },
             AppError::CouldntCreateDataDirectory(_) => Some(101),
             AppError::CouldntInitializeDatabase(_) => Some(102),
             AppError::DBPathNotValidStr => None,

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -3,7 +3,7 @@ use crate::cli::*;
 use crate::errors::AppError;
 use crate::persistence::get_db_pool;
 use crate::tui::{run_tui, TuiContext};
-use dirs::data_dir;
+use crate::utils::get_data_dir;
 use std::fs;
 use std::path::PathBuf;
 
@@ -14,7 +14,7 @@ pub async fn handle(args: Args) -> Result<(), AppError> {
     let db_path = match &args.db_path {
         Some(p) => PathBuf::from(p),
         None => {
-            let user_data_dir = data_dir().ok_or(AppError::CouldntGetDataDirectory)?;
+            let user_data_dir = get_data_dir().map_err(AppError::CouldntGetDataDirectory)?;
             let data_dir = user_data_dir.join(PathBuf::from(DATA_DIR));
 
             if !data_dir.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod errors;
 mod handle;
 mod persistence;
 mod tui;
+mod utils;
 
 use args::Args;
 use clap::Parser;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 #[derive(thiserror::Error, Debug)]
 pub enum DataDirError {
+    #[cfg(target_family = "unix")]
     #[error("XDG_DATA_HOME is not an absolute path")]
     XDGDataHomeNotAbsolute,
     #[error("couldn't get your data directory")]
@@ -9,7 +10,7 @@ pub enum DataDirError {
 }
 
 pub fn get_data_dir() -> Result<PathBuf, DataDirError> {
-    #[cfg(target_os = "macos")]
+    #[cfg(target_family = "unix")]
     let data_dir = match std::env::var_os("XDG_DATA_HOME").map(PathBuf::from) {
         Some(p) => {
             if p.is_absolute() {
@@ -24,7 +25,7 @@ pub fn get_data_dir() -> Result<PathBuf, DataDirError> {
         },
     }?;
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(target_family = "unix"))]
     let data_dir = dirs::data_dir().ok_or(DataDirError::CouldntGetDataDir)?;
 
     Ok(data_dir)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,31 @@
+use std::path::PathBuf;
+
+#[derive(thiserror::Error, Debug)]
+pub enum DataDirError {
+    #[error("XDG_DATA_HOME is not an absolute path")]
+    XDGDataHomeNotAbsolute,
+    #[error("couldn't get your data directory")]
+    CouldntGetDataDir,
+}
+
+pub fn get_data_dir() -> Result<PathBuf, DataDirError> {
+    #[cfg(target_os = "macos")]
+    let data_dir = match std::env::var_os("XDG_DATA_HOME").map(PathBuf::from) {
+        Some(p) => {
+            if p.is_absolute() {
+                Ok(p)
+            } else {
+                Err(DataDirError::XDGDataHomeNotAbsolute)
+            }
+        }
+        None => match dirs::data_dir() {
+            Some(p) => Ok(p),
+            None => Err(DataDirError::CouldntGetDataDir),
+        },
+    }?;
+
+    #[cfg(not(target_os = "macos"))]
+    let data_dir = dirs::data_dir().ok_or(DataDirError::CouldntGetDataDir)?;
+
+    Ok(data_dir)
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -7,6 +7,7 @@ pub struct Fixture {
 }
 
 #[cfg(test)]
+#[allow(unused)]
 impl Fixture {
     pub fn new() -> Self {
         let temp_dir = tempdir().expect("temporary directory should've been created");

--- a/tests/data_dir_test.rs
+++ b/tests/data_dir_test.rs
@@ -1,7 +1,6 @@
 mod common;
 use assert_cmd::Command;
 use common::{ExpectedFailure, ExpectedSuccess};
-use pretty_assertions::assert_eq;
 use tempfile::tempdir;
 
 const URI: &str = "https://crates.io/crates/sqlx";
@@ -10,9 +9,8 @@ const URI: &str = "https://crates.io/crates/sqlx";
 //  SUCCESSES  //
 //-------------//
 
-#[cfg(target_os = "macos")]
 #[test]
-fn xdg_config_is_respected_on_darwin() {
+fn xdg_data_home_is_respected() {
     // GIVEN
     let temp_dir = tempdir().expect("temporary directory should've been created");
     let data_dir_path = temp_dir
@@ -28,37 +26,30 @@ fn xdg_config_is_respected_on_darwin() {
     let import_output = import_cmd.output().expect("import command should've run");
     assert!(import_output.status.success());
 
+    let mut cmd_without_env_var =
+        Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("command should've been created");
+    cmd_without_env_var.args(["show", URI]);
     let mut cmd =
         Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("command should've been created");
     cmd.args(["show", URI]);
     cmd.env("XDG_DATA_HOME", &data_dir_path);
 
     // WHEN
+    let output_for_without_env_var = cmd_without_env_var.output().expect("command should've run");
     let output = cmd.output().expect("command should've run");
 
     // THEN
-    output.print_stderr_if_failed(None);
+    output_for_without_env_var.print_stdout_if_succeeded(Some("without env var"));
+    output.print_stderr_if_failed(Some("with env var"));
+    assert!(!output_for_without_env_var.status.success());
     assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).expect("invalid utf-8 stdout");
-    assert_eq!(
-        stdout.trim(),
-        "
-Bookmark details
----
-
-Title: sqlx - crates.io: Rust Package Registry
-URI  : https://crates.io/crates/sqlx
-Tags : crates,rust
-"
-        .trim()
-    );
 }
 
 //------------//
 //  FAILURES  //
 //------------//
 
-#[cfg(target_os = "macos")]
+#[cfg(target_family = "unix")]
 #[test]
 fn fails_if_xdg_data_home_is_non_absolute() {
     // GIVEN

--- a/tests/data_dir_test.rs
+++ b/tests/data_dir_test.rs
@@ -1,0 +1,78 @@
+mod common;
+use assert_cmd::Command;
+use common::{ExpectedFailure, ExpectedSuccess};
+use pretty_assertions::assert_eq;
+use tempfile::tempdir;
+
+const URI: &str = "https://crates.io/crates/sqlx";
+
+//-------------//
+//  SUCCESSES  //
+//-------------//
+
+#[cfg(target_os = "macos")]
+#[test]
+fn xdg_config_is_respected_on_darwin() {
+    // GIVEN
+    let temp_dir = tempdir().expect("temporary directory should've been created");
+    let data_dir_path = temp_dir
+        .path()
+        .to_str()
+        .expect("temporary directory path is not valid utf-8")
+        .to_string();
+    let mut import_cmd =
+        Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("command should've been created");
+    import_cmd.args(["import", "tests/static/import/valid.json"]);
+    import_cmd.env("XDG_DATA_HOME", &data_dir_path);
+
+    let import_output = import_cmd.output().expect("import command should've run");
+    assert!(import_output.status.success());
+
+    let mut cmd =
+        Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("command should've been created");
+    cmd.args(["show", URI]);
+    cmd.env("XDG_DATA_HOME", &data_dir_path);
+
+    // WHEN
+    let output = cmd.output().expect("command should've run");
+
+    // THEN
+    output.print_stderr_if_failed(None);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("invalid utf-8 stdout");
+    assert_eq!(
+        stdout.trim(),
+        "
+Bookmark details
+---
+
+Title: sqlx - crates.io: Rust Package Registry
+URI  : https://crates.io/crates/sqlx
+Tags : crates,rust
+"
+        .trim()
+    );
+}
+
+//------------//
+//  FAILURES  //
+//------------//
+
+#[cfg(target_os = "macos")]
+#[test]
+fn fails_if_xdg_data_home_is_non_absolute() {
+    // GIVEN
+    let mut cmd =
+        Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("command should've been created");
+    cmd.args(["show", URI]);
+    cmd.env("XDG_DATA_HOME", "../not/an/absolute/path");
+
+    // WHEN
+    let output = cmd.output().expect("command should've run");
+
+    // THEN
+    output.print_stdout_if_succeeded(None);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("invalid utf-8 stderr");
+    assert!(stderr.contains("XDG_DATA_HOME is not an absolute path"));
+}


### PR DESCRIPTION
This makes MacOS behave like linux, allowing the user to override MacOS
default data directory.
