### PR TITLE
feat: allow ignoring attribute errors while saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Allow ignoring attribute errors while saving/importing bookmarks (longer
+    titles will be trimmed, some invalid tags will be corrected)
+
 ## [v0.2.0] - Feb 27, 2025
 
 ### Changed

--- a/src/args.rs
+++ b/src/args.rs
@@ -92,7 +92,7 @@ pub enum BmmCommand {
             value_name = "STRING,STRING..",
             value_delimiter = ','
         )]
-        tags: Option<Vec<String>>,
+        tags: Vec<String>,
         /// Provide details via a text editor
         #[arg(short = 'e', long = "editor")]
         use_editor: bool,
@@ -102,6 +102,9 @@ pub enum BmmCommand {
         /// Reset previously saved details if not provided
         #[arg(short = 'r', long = "reset-missing-details")]
         reset_missing: bool,
+        /// Ignore errors related to bookmark title and tags: if title is too long, it'll be trimmed, some invalid tags will be corrected.
+        #[arg(short = 'i', long = "ignore-attribute-errors")]
+        ignore_attribute_errors: bool,
     },
     /// Save/update multiple bookmarks
     SaveAll {
@@ -115,7 +118,7 @@ pub enum BmmCommand {
             value_name = "STRING,STRING..",
             value_delimiter = ','
         )]
-        tags: Option<Vec<String>>,
+        tags: Vec<String>,
         /// Read input from stdin
         #[arg(short = 's', long = "stdin")]
         use_stdin: bool,
@@ -282,6 +285,7 @@ reset missing : {}
                 use_editor,
                 fail_if_uri_already_saved,
                 reset_missing,
+                ignore_attribute_errors,
             } => format!(
                 r#"
 command                   : Save/update bookmark
@@ -291,13 +295,15 @@ tags                      : {}
 use editor                : {}
 fail if URI already saved : {}
 reset missing             : {}
+ignore attribute errors   : {}
 "#,
                 uri,
                 title.as_deref().unwrap_or(NOT_PROVIDED),
-                tags.as_ref().map_or(NOT_PROVIDED.into(), |t| t.join(" ")),
+                tags.join(" "),
                 use_editor,
                 fail_if_uri_already_saved,
                 reset_missing,
+                ignore_attribute_errors,
             ),
             BmmCommand::SaveAll {
                 uris,
@@ -313,7 +319,7 @@ use stdin                 : {}
 reset missing             : {}
 "#,
                 uris.as_ref().map_or(NOT_PROVIDED.into(), |u| u.join(" ")),
-                tags.as_ref().map_or(NOT_PROVIDED.into(), |t| t.join(" ")),
+                tags.join(" "),
                 use_stdin,
                 reset_missing,
             ),

--- a/src/args.rs
+++ b/src/args.rs
@@ -34,6 +34,9 @@ pub enum BmmCommand {
         /// Reset previously saved details if not provided
         #[arg(short = 'r', long = "reset-missing-details")]
         reset_missing: bool,
+        /// Ignore errors related to bookmark title and tags; if title is too long, it'll be trimmed, some invalid tags will be corrected
+        #[arg(short = 'i', long = "ignore-attribute-errors")]
+        ignore_attribute_errors: bool,
     },
     /// Delete bookmarks
     Delete {
@@ -102,7 +105,7 @@ pub enum BmmCommand {
         /// Reset previously saved details if not provided
         #[arg(short = 'r', long = "reset-missing-details")]
         reset_missing: bool,
-        /// Ignore errors related to bookmark title and tags: if title is too long, it'll be trimmed, some invalid tags will be corrected.
+        /// Ignore errors related to bookmark title and tags; if title is too long, it'll be trimmed, some invalid tags will be corrected
         #[arg(short = 'i', long = "ignore-attribute-errors")]
         ignore_attribute_errors: bool,
     },
@@ -125,6 +128,9 @@ pub enum BmmCommand {
         /// Reset previously saved tags if not provided
         #[arg(short = 'r', long = "reset-missing-details")]
         reset_missing: bool,
+        /// Ignore errors related to bookmark tags; some invalid tags will be corrected
+        #[arg(short = 'i', long = "ignore-attribute-errors")]
+        ignore_attribute_errors: bool,
     },
     /// Search bookmarks by matching over terms
     Search {
@@ -269,14 +275,16 @@ limit             : {}
                 file,
                 dry_run,
                 reset_missing,
+                ignore_attribute_errors,
             } => format!(
                 r#"
 command       : Import bookmarks
 file          : {}
 dry run       : {}
 reset missing : {}
+ignore attribute errors   : {}
 "#,
-                file, dry_run, reset_missing
+                file, dry_run, reset_missing, ignore_attribute_errors,
             ),
             BmmCommand::Save {
                 uri,
@@ -310,6 +318,7 @@ ignore attribute errors   : {}
                 tags,
                 use_stdin,
                 reset_missing,
+                ignore_attribute_errors,
             } => format!(
                 r#"
 command                   : Save/update bookmarks
@@ -317,11 +326,13 @@ URIs                      : {}
 tags                      : {}
 use stdin                 : {}
 reset missing             : {}
+ignore attribute errors   : {}
 "#,
                 uris.as_ref().map_or(NOT_PROVIDED.into(), |u| u.join(" ")),
                 tags.join(" "),
                 use_stdin,
                 reset_missing,
+                ignore_attribute_errors,
             ),
             BmmCommand::Search {
                 query_terms,

--- a/src/cli/save_all.rs
+++ b/src/cli/save_all.rs
@@ -1,5 +1,5 @@
 use crate::common::IMPORT_UPPER_LIMIT;
-use crate::domain::{DraftBookmark, DraftBookmarkErrors};
+use crate::domain::{DraftBookmark, DraftBookmarkErrors, PotentialBookmark};
 use crate::persistence::{DBError, SaveBookmarkOptions, create_or_update_bookmarks};
 use sqlx::{Pool, Sqlite};
 use std::io::BufRead;
@@ -28,7 +28,7 @@ pub struct SaveAllStats {
 pub async fn save_all_bookmarks(
     pool: &Pool<Sqlite>,
     uris: Option<Vec<String>>,
-    tags: Option<Vec<String>>,
+    tags: Vec<String>,
     use_stdin: bool,
     reset_missing: bool,
 ) -> Result<Option<SaveAllStats>, SaveBookmarksError> {
@@ -48,11 +48,9 @@ pub async fn save_all_bookmarks(
     let mut validation_errors = Vec::new();
     let mut draft_bookmarks = Vec::new();
 
-    let tags_to_save = tags.unwrap_or_default();
-    let tags_ref = tags_to_save.iter().map(|t| t.as_str()).collect::<Vec<_>>();
-
     for (index, uri) in uris_to_save.into_iter().enumerate() {
-        let db_result = DraftBookmark::try_from((uri.as_str(), None, &tags_ref));
+        let potential_bookmark = PotentialBookmark::from((uri, None, &tags));
+        let db_result = DraftBookmark::try_from(potential_bookmark);
         match db_result {
             Ok(db) => draft_bookmarks.push(db),
             Err(e) => validation_errors.push((index, e)),

--- a/src/cli/save_all.rs
+++ b/src/cli/save_all.rs
@@ -31,6 +31,7 @@ pub async fn save_all_bookmarks(
     tags: Vec<String>,
     use_stdin: bool,
     reset_missing: bool,
+    ignore_attribute_errors: bool,
 ) -> Result<Option<SaveAllStats>, SaveBookmarksError> {
     let mut uris_to_save = uris.unwrap_or_default();
 
@@ -50,7 +51,7 @@ pub async fn save_all_bookmarks(
 
     for (index, uri) in uris_to_save.into_iter().enumerate() {
         let potential_bookmark = PotentialBookmark::from((uri, None, &tags));
-        let db_result = DraftBookmark::try_from(potential_bookmark);
+        let db_result = DraftBookmark::try_from((potential_bookmark, ignore_attribute_errors));
         match db_result {
             Ok(db) => draft_bookmarks.push(db),
             Err(e) => validation_errors.push((index, e)),

--- a/src/domain/bookmark.rs
+++ b/src/domain/bookmark.rs
@@ -250,9 +250,10 @@ impl TryFrom<PotentialBookmark> for DraftBookmark {
 impl TryFrom<(PotentialImportedBookmark, bool)> for DraftBookmark {
     type Error = DraftBookmarkError;
 
-    fn try_from(value: (PotentialImportedBookmark, bool)) -> Result<Self, Self::Error> {
-        let potential_bookmark = PotentialBookmark::from(value.0);
-        Self::try_from((potential_bookmark, value.1))
+    fn try_from(tuple: (PotentialImportedBookmark, bool)) -> Result<Self, Self::Error> {
+        let (potential_imported_bookmark, ignore_attribute_errors) = tuple;
+        let potential_bookmark = PotentialBookmark::from(potential_imported_bookmark);
+        Self::try_from((potential_bookmark, ignore_attribute_errors))
     }
 }
 

--- a/src/domain/bookmark.rs
+++ b/src/domain/bookmark.rs
@@ -1,4 +1,6 @@
 use super::tags::{TAG_REGEX_STR, Tag};
+use once_cell::sync::Lazy;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use url::{ParseError, Url};
 
@@ -15,7 +17,79 @@ pub struct DraftBookmark {
 pub struct PotentialBookmark {
     pub uri: String,
     pub title: Option<String>,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PotentialImportedBookmark {
+    pub uri: String,
+    pub title: Option<String>,
     pub tags: Option<String>,
+}
+
+impl From<PotentialImportedBookmark> for PotentialBookmark {
+    fn from(bookmark: PotentialImportedBookmark) -> Self {
+        Self {
+            uri: bookmark.uri,
+            title: bookmark.title,
+            tags: bookmark
+                .tags
+                .unwrap_or_default()
+                .split(",")
+                .map(|t| t.to_string())
+                .collect::<Vec<_>>(),
+        }
+    }
+}
+
+impl<T> From<(T, Option<T>, Option<T>)> for PotentialImportedBookmark
+where
+    T: AsRef<str>,
+{
+    fn from(tuple: (T, Option<T>, Option<T>)) -> Self {
+        let (uri, title, tags) = tuple;
+        Self {
+            uri: uri.as_ref().to_string(),
+            title: title.map(|t| t.as_ref().to_string()),
+            tags: tags.map(|t| t.as_ref().to_string()),
+        }
+    }
+}
+
+impl<T> From<(T, Option<T>, Option<T>)> for PotentialBookmark
+where
+    T: AsRef<str>,
+{
+    fn from(tuple: (T, Option<T>, Option<T>)) -> Self {
+        let (uri, title, tags) = tuple;
+        Self {
+            uri: uri.as_ref().to_string(),
+            title: title.map(|t| t.as_ref().to_string()),
+            tags: tags
+                .map(|t| t.as_ref().to_string())
+                .unwrap_or_default()
+                .split(",")
+                .map(|t| t.to_string())
+                .collect::<Vec<_>>(),
+        }
+    }
+}
+
+impl<T> From<(T, Option<T>, &Vec<T>)> for PotentialBookmark
+where
+    T: AsRef<str>,
+{
+    fn from(tuple: (T, Option<T>, &Vec<T>)) -> Self {
+        let (uri, title, tags) = tuple;
+        Self {
+            uri: uri.as_ref().to_string(),
+            title: title.map(|t| t.as_ref().to_string()),
+            tags: tags
+                .iter()
+                .map(|t| t.as_ref().to_string())
+                .collect::<Vec<_>>(),
+        }
+    }
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -78,111 +152,116 @@ impl std::fmt::Display for DraftBookmarkErrors {
     }
 }
 
-impl TryFrom<(&str, Option<&str>, &Vec<&str>)> for DraftBookmark {
+impl TryFrom<(PotentialBookmark, bool)> for DraftBookmark {
     type Error = DraftBookmarkError;
 
-    fn try_from(value: (&str, Option<&str>, &Vec<&str>)) -> Result<Self, Self::Error> {
-        let (uri, title, tags) = value;
+    fn try_from(value: (PotentialBookmark, bool)) -> Result<Self, Self::Error> {
+        #[allow(clippy::expect_used)]
+        static WHITESPACE_RE: Lazy<Regex> =
+            Lazy::new(|| Regex::new(r"\s+").expect("regex is invalid"));
 
-        Url::parse(uri).map_err(DraftBookmarkError::CouldntParseUri)?;
+        let (potential_bookmark, ignore_attribute_errors) = value;
+        let tags = &potential_bookmark.tags;
 
-        if let Some(t) = title {
-            let title_len = t.len();
-            if title_len > TAG_TITLE_MAX_LENGTH {
-                return Err(DraftBookmarkError::TitleTooLong(title_len));
+        Url::parse(&potential_bookmark.uri).map_err(DraftBookmarkError::CouldntParseUri)?;
+
+        let title = match ignore_attribute_errors {
+            true => potential_bookmark
+                .title
+                .as_ref()
+                .map(|t| t.trim())
+                .and_then(|t| {
+                    if t.is_empty() {
+                        None
+                    } else if t.len() > TAG_TITLE_MAX_LENGTH {
+                        t.get(0..TAG_TITLE_MAX_LENGTH)
+                    } else {
+                        Some(t)
+                    }
+                })
+                .map(|t| t.to_string()),
+            false => {
+                if let Some(t) = &potential_bookmark.title {
+                    let title_len = t.len();
+                    if title_len > TAG_TITLE_MAX_LENGTH {
+                        return Err(DraftBookmarkError::TitleTooLong(title_len));
+                    }
+                };
+
+                potential_bookmark.title.as_ref().and_then(|t| {
+                    let trimmed = t.trim();
+                    if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed.to_string())
+                    }
+                })
             }
         };
 
-        let title_to_save = title.and_then(|t| {
-            let trimmed = t.trim();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed.to_string())
-            }
-        });
+        let tags = match ignore_attribute_errors {
+            true => potential_bookmark
+                .tags
+                .iter()
+                .map(|t| t.trim())
+                .filter(|t| !t.is_empty())
+                .map(|t| WHITESPACE_RE.replace_all(t, "-").to_string())
+                .filter_map(|t| Tag::try_from(t.as_str()).ok())
+                .collect::<Vec<_>>(),
+            false => {
+                let mut tags = Vec::with_capacity(tags.len());
+                let mut invalid_tags = Vec::new();
+                for tag in potential_bookmark.tags {
+                    if tag.is_empty() {
+                        continue;
+                    }
 
-        let mut tags_to_save = Vec::with_capacity(tags.len());
-        let mut invalid_tags = Vec::new();
-        for tag in tags {
-            if tag.is_empty() {
-                continue;
-            }
+                    match Tag::try_from(tag.as_str()) {
+                        Ok(t) => tags.push(t),
+                        Err(_) => invalid_tags.push(tag.to_string()),
+                    }
+                }
+                if !invalid_tags.is_empty() {
+                    return Err(DraftBookmarkError::TagIsInvalid(invalid_tags));
+                }
 
-            match Tag::try_from(tag) {
-                Ok(t) => tags_to_save.push(t),
-                Err(_) => invalid_tags.push(tag.to_string()),
+                tags.sort();
+                tags.dedup();
+                tags
             }
-        }
-        if !invalid_tags.is_empty() {
-            return Err(DraftBookmarkError::TagIsInvalid(invalid_tags));
-        }
-
-        tags_to_save.sort();
-        tags_to_save.dedup();
+        };
 
         Ok(Self {
-            uri: uri.to_string(),
-            title: title_to_save,
-            tags: tags_to_save,
+            uri: potential_bookmark.uri,
+            title,
+            tags,
         })
     }
 }
 
-impl TryFrom<(&str, Option<&str>, Option<&str>)> for DraftBookmark {
+impl TryFrom<PotentialBookmark> for DraftBookmark {
     type Error = DraftBookmarkError;
 
-    fn try_from(value: (&str, Option<&str>, Option<&str>)) -> Result<Self, Self::Error> {
-        let (uri, title, tags) = value;
-        let tags = tags.map(|t| t.split(",").collect::<Vec<_>>());
-        Self::try_from((uri, title, &tags.unwrap_or_default()))
+    fn try_from(potential_bookmark: PotentialBookmark) -> Result<Self, Self::Error> {
+        Self::try_from((potential_bookmark, false))
     }
 }
 
-impl TryFrom<(&str, Option<&str>, Option<String>)> for DraftBookmark {
+impl TryFrom<(PotentialImportedBookmark, bool)> for DraftBookmark {
     type Error = DraftBookmarkError;
 
-    fn try_from(value: (&str, Option<&str>, Option<String>)) -> Result<Self, Self::Error> {
-        let (uri, title, tags) = value;
-        Self::try_from((uri, title, tags.as_deref()))
+    fn try_from(value: (PotentialImportedBookmark, bool)) -> Result<Self, Self::Error> {
+        let potential_bookmark = PotentialBookmark::from(value.0);
+        Self::try_from((potential_bookmark, value.1))
     }
 }
 
-impl TryFrom<(&str, Option<&str>, Option<Vec<String>>)> for DraftBookmark {
+impl TryFrom<PotentialImportedBookmark> for DraftBookmark {
     type Error = DraftBookmarkError;
 
-    fn try_from(value: (&str, Option<&str>, Option<Vec<String>>)) -> Result<Self, Self::Error> {
-        let (uri, title, tags) = value;
-        let tags_ref = tags
-            .as_ref()
-            .map(|v| v.iter().map(|t| t.as_str()).collect::<Vec<_>>());
-        Self::try_from((uri, title, &tags_ref.unwrap_or_default()))
-    }
-}
-
-impl TryFrom<&String> for DraftBookmark {
-    type Error = DraftBookmarkError;
-
-    fn try_from(uri: &String) -> Result<Self, Self::Error> {
-        Self::try_from((uri.as_str(), None, &Vec::new()))
-    }
-}
-
-impl TryFrom<&str> for DraftBookmark {
-    type Error = DraftBookmarkError;
-
-    fn try_from(uri: &str) -> Result<Self, Self::Error> {
-        Self::try_from((uri, None, &Vec::new()))
-    }
-}
-
-impl TryFrom<&PotentialBookmark> for DraftBookmark {
-    type Error = DraftBookmarkError;
-
-    fn try_from(value: &PotentialBookmark) -> Result<Self, Self::Error> {
-        let t: Vec<&str> = value.tags.as_deref().unwrap_or("").split(",").collect();
-
-        Self::try_from((value.uri.as_str(), value.title.as_deref(), &t))
+    fn try_from(value: PotentialImportedBookmark) -> Result<Self, Self::Error> {
+        let potential_bookmark = PotentialBookmark::from(value);
+        Self::try_from((potential_bookmark, false))
     }
 }
 
@@ -231,9 +310,10 @@ mod tests {
         let uri = "https://github.com/launchbadge/sqlx";
         let title = "sqlx's github page";
         let tags = vec!["sql", "rust", "database-library-1"];
+        let potential_bookmark = PotentialBookmark::from((uri, Some(title), &tags));
 
         // WHEN
-        let result = DraftBookmark::try_from((uri, Some(title), &tags));
+        let result = DraftBookmark::try_from(potential_bookmark);
 
         // THEN
         assert!(result.is_ok());
@@ -245,13 +325,67 @@ mod tests {
         let uri = "https://github.com/launchbadge/sqlx";
         let title = "sqlx's github page";
         let tags = vec!["sql", "", "database-library", ""];
+        let potential_bookmark = PotentialBookmark::from((uri, Some(title), &tags));
 
         // WHEN
-        let result = DraftBookmark::try_from((uri, Some(title), &tags))
+        let result = DraftBookmark::try_from(potential_bookmark)
             .expect("draft bookmark should've been created");
 
         // THEN
         assert_eq!(result.tags(), vec!["database-library", "sql"]);
+    }
+
+    #[test]
+    fn force_creating_a_draft_bookmark_with_too_long_a_title_works() {
+        // GIVEN
+        let uri = "https://github.com/launchbadge/sqlx";
+        let title = "a".repeat(501);
+        let tags = vec![];
+        let potential_bookmark = PotentialBookmark::from((uri, Some(title.as_str()), &tags));
+
+        // WHEN
+        let draft_bookmark = DraftBookmark::try_from((potential_bookmark, true))
+            .expect("draft bookmark should've been created");
+
+        // THEN
+        assert_eq!(
+            draft_bookmark.title.map(|t| t.len()),
+            Some(TAG_TITLE_MAX_LENGTH)
+        );
+    }
+
+    #[test]
+    fn force_creating_a_draft_bookmark_with_invalid_tags_works() {
+        // GIVEN
+        let uri = "https://github.com/launchbadge/sqlx";
+        let tags = vec![
+            "tag with spaces",
+            "tag\twith\ttabs",
+            "tag with trailing space   ",
+            "  tag with leading space",
+            "  tag with\t\tboth\ttabs and spaces  ",
+            "inv@lid-t@g",
+            "!!",
+            "",
+            "??",
+        ];
+        let potential_bookmark = PotentialBookmark::from((uri, None, &tags));
+
+        // WHEN
+        let draft_bookmark = DraftBookmark::try_from((potential_bookmark, true))
+            .expect("draft bookmark should've been created");
+
+        // THEN
+        assert_eq!(
+            draft_bookmark.tags(),
+            vec![
+                "tag-with-spaces",
+                "tag-with-tabs",
+                "tag-with-trailing-space",
+                "tag-with-leading-space",
+                "tag-with-both-tabs-and-spaces"
+            ]
+        );
     }
 
     //------------//
@@ -260,7 +394,6 @@ mod tests {
 
     #[test]
     fn draft_bookmark_cannot_be_created_with_an_incorrect_uri() {
-        // GIVEN
         let faulty_uris = vec![
             "https:://github.com/launchbadge/sqlx",
             "github.com/launchbadge/sqlx",
@@ -269,8 +402,10 @@ mod tests {
         ];
 
         for uri in faulty_uris {
+            // GIVEN
+            let potential_bookmark = PotentialBookmark::from((uri, None, None));
             // WHEN
-            let result = DraftBookmark::try_from((uri, None, &Vec::new()));
+            let result = DraftBookmark::try_from(potential_bookmark);
 
             // THEN
             match result {
@@ -285,9 +420,10 @@ mod tests {
         // GIVEN
         let uri = "https://github.com/launchbadge/sqlx";
         let title = "a".repeat(501);
+        let potential_bookmark = PotentialBookmark::from((uri, Some(title.as_str()), None));
 
         // WHEN
-        let result = DraftBookmark::try_from((uri, Some(title.as_str()), &Vec::new()));
+        let result = DraftBookmark::try_from(potential_bookmark);
 
         // THEN
         match result {
@@ -310,7 +446,8 @@ mod tests {
 
         for tag in malformed_tags {
             // WHEN
-            let result = DraftBookmark::try_from((uri, Some(title), &vec![tag]));
+            let potential_bookmark = PotentialBookmark::from((uri, Some(title), &vec![tag]));
+            let result = DraftBookmark::try_from(potential_bookmark);
 
             // THEN
             match result {

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,5 +1,6 @@
 use crate::args::{Args, BmmCommand, TagsCommand};
 use crate::cli::*;
+use crate::domain::PotentialBookmark;
 use crate::errors::AppError;
 use crate::persistence::get_db_pool;
 use crate::tui::{TuiContext, run_tui};
@@ -75,15 +76,17 @@ pub async fn handle(args: Args) -> Result<(), AppError> {
             use_editor,
             fail_if_uri_already_saved,
             reset_missing,
+            ignore_attribute_errors,
         } => {
+            let potential_bookmark = PotentialBookmark::from((uri, title, &tags));
+
             save_bookmark(
                 &pool,
-                uri,
-                title,
-                tags,
+                potential_bookmark,
                 use_editor,
                 fail_if_uri_already_saved,
                 reset_missing,
+                ignore_attribute_errors,
             )
             .await?
         }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -47,8 +47,16 @@ pub async fn handle(args: Args) -> Result<(), AppError> {
             file,
             reset_missing,
             dry_run,
+            ignore_attribute_errors,
         } => {
-            let result = import_bookmarks(&pool, &file, reset_missing, dry_run).await?;
+            let result = import_bookmarks(
+                &pool,
+                &file,
+                reset_missing,
+                dry_run,
+                ignore_attribute_errors,
+            )
+            .await?;
             if let Some(stats) = result {
                 println!("imported {} bookmarks", stats.num_bookmarks_imported);
             }
@@ -96,8 +104,17 @@ pub async fn handle(args: Args) -> Result<(), AppError> {
             tags,
             use_stdin,
             reset_missing,
+            ignore_attribute_errors,
         } => {
-            let result = save_all_bookmarks(&pool, uris, tags, use_stdin, reset_missing).await?;
+            let result = save_all_bookmarks(
+                &pool,
+                uris,
+                tags,
+                use_stdin,
+                reset_missing,
+                ignore_attribute_errors,
+            )
+            .await?;
             if let Some(stats) = result {
                 println!("saved {} bookmarks", stats.num_bookmarks);
             }

--- a/src/persistence/create.rs
+++ b/src/persistence/create.rs
@@ -383,6 +383,7 @@ mod tests {
     };
     use super::super::test_fixtures::DBPoolFixture;
     use super::*;
+    use crate::domain::PotentialBookmark;
     use pretty_assertions::assert_eq;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -393,8 +394,9 @@ mod tests {
         let tags = vec!["rust", "sqlite"];
         let uri = "https://github.com/launchbadge/sqlx";
         let title = "sqlx's github page";
-        let draft_bookmark = DraftBookmark::try_from((uri, Some(title), &tags))
-            .expect("draft bookmark should've been created");
+        let draft_bookmark =
+            DraftBookmark::try_from(PotentialBookmark::from((uri, Some(title), &tags)))
+                .expect("draft bookmark should've been created");
         let start = SystemTime::now();
         let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
         let now = since_the_epoch.as_secs() as i64;
@@ -440,7 +442,7 @@ mod tests {
         let fixture = DBPoolFixture::new().await;
         let tags = vec!["rust", "sqlite"];
         let uri = "https://github.com/launchbadge/sqlx";
-        let draft_bookmark = DraftBookmark::try_from((uri, None, &tags))
+        let draft_bookmark = DraftBookmark::try_from(PotentialBookmark::from((uri, None, &tags)))
             .expect("draft bookmark should've been created");
         let start = SystemTime::now();
         let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
@@ -487,8 +489,9 @@ mod tests {
         let fixture = DBPoolFixture::new().await;
         let uri = "https://github.com/launchbadge/sqlx";
         let title = "sqlx's github page";
-        let draft_bookmark = DraftBookmark::try_from((uri, Some(title), &vec![]))
-            .expect("draft bookmark should've been created");
+        let draft_bookmark =
+            DraftBookmark::try_from(PotentialBookmark::from((uri, Some(title), &vec![])))
+                .expect("draft bookmark should've been created");
         let start = SystemTime::now();
         let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
         let now = since_the_epoch.as_secs() as i64;
@@ -527,8 +530,9 @@ mod tests {
         let old_tags = vec!["rust", "sqlite"];
         let uri = "https://github.com/launchbadge/sqlx";
         let title_old = "sqlx's github page";
-        let draft_bookmark_old = DraftBookmark::try_from((uri, Some(title_old), &old_tags))
-            .expect("draft bookmark should've been created");
+        let draft_bookmark_old =
+            DraftBookmark::try_from(PotentialBookmark::from((uri, Some(title_old), &old_tags)))
+                .expect("draft bookmark should've been created");
         let start = SystemTime::now();
         let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
         let now = since_the_epoch.as_secs() as i64;
@@ -544,8 +548,7 @@ mod tests {
         .expect("bookmark should've been saved the first time");
 
         // WHEN
-        let new_tags: Option<&str> = None;
-        let draft_bookmark = DraftBookmark::try_from((uri, None, new_tags))
+        let draft_bookmark = DraftBookmark::try_from(PotentialBookmark::from((uri, None, None)))
             .expect("draft bookmark should've been created");
         let result = create_or_update_bookmark(
             &fixture.pool,
@@ -583,8 +586,9 @@ mod tests {
         let old_tags = vec!["rust", "sqlite"];
         let uri = "https://github.com/launchbadge/sqlx";
         let title_old = "sqlx's github page";
-        let draft_bookmark_old = DraftBookmark::try_from((uri, Some(title_old), &old_tags))
-            .expect("draft bookmark should've been created");
+        let draft_bookmark_old =
+            DraftBookmark::try_from(PotentialBookmark::from((uri, Some(title_old), &old_tags)))
+                .expect("draft bookmark should've been created");
         let start = SystemTime::now();
         let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
         let now = since_the_epoch.as_secs() as i64;
@@ -601,8 +605,9 @@ mod tests {
 
         // WHEN
         let new_tags = vec!["rust", "github", "database"];
-        let draft_bookmark = DraftBookmark::try_from((uri, None, &new_tags))
-            .expect("draft bookmark should've been created");
+        let draft_bookmark =
+            DraftBookmark::try_from(PotentialBookmark::from((uri, None, &new_tags)))
+                .expect("draft bookmark should've been created");
         let result = create_or_update_bookmark(
             &fixture.pool,
             &draft_bookmark,
@@ -647,8 +652,9 @@ mod tests {
         let old_tags = vec!["rust", "sqlite"];
         let uri = "https://github.com/launchbadge/sqlx";
         let title_old = "sqlx's github page";
-        let draft_bookmark_old = DraftBookmark::try_from((uri, Some(title_old), &old_tags))
-            .expect("draft bookmark should've been created");
+        let draft_bookmark_old =
+            DraftBookmark::try_from(PotentialBookmark::from((uri, Some(title_old), &old_tags)))
+                .expect("draft bookmark should've been created");
         let start = SystemTime::now();
         let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
         let now = since_the_epoch.as_secs() as i64;
@@ -665,8 +671,9 @@ mod tests {
 
         // WHEN
         let title_new = "sqlx's github repository";
-        let draft_bookmark = DraftBookmark::try_from((uri, Some(title_new), &old_tags))
-            .expect("draft bookmark should've been created");
+        let draft_bookmark =
+            DraftBookmark::try_from(PotentialBookmark::from((uri, Some(title_new), &old_tags)))
+                .expect("draft bookmark should've been created");
         let save_options = SaveBookmarkOptions {
             reset_missing_attributes: true,
             reset_tags: true,
@@ -701,8 +708,9 @@ mod tests {
         let old_tags = vec!["rust", "sqlite"];
         let uri = "https://github.com/launchbadge/sqlx";
         let title_old = "sqlx's github page";
-        let draft_bookmark_old = DraftBookmark::try_from((uri, Some(title_old), &old_tags))
-            .expect("draft bookmark should've been created");
+        let draft_bookmark_old =
+            DraftBookmark::try_from(PotentialBookmark::from((uri, Some(title_old), &old_tags)))
+                .expect("draft bookmark should've been created");
         let start = SystemTime::now();
         let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
         let now = since_the_epoch.as_secs() as i64;
@@ -719,8 +727,9 @@ mod tests {
 
         // WHEN
         let new_tags = vec!["rust", "github", "database"];
-        let draft_bookmark = DraftBookmark::try_from((uri, Some(title_old), &new_tags))
-            .expect("draft bookmark should've been created");
+        let draft_bookmark =
+            DraftBookmark::try_from(PotentialBookmark::from((uri, Some(title_old), &new_tags)))
+                .expect("draft bookmark should've been created");
         let save_options = SaveBookmarkOptions {
             reset_missing_attributes: false,
             reset_tags: true,
@@ -752,8 +761,9 @@ mod tests {
         let fixture = DBPoolFixture::new().await;
         let uri = "https://github.com/launchbadge/sqlx";
         let title_old = "sqlx's github page";
-        let draft_bookmark_old = DraftBookmark::try_from((uri, Some(title_old), &vec![]))
-            .expect("draft bookmark should've been created");
+        let draft_bookmark_old =
+            DraftBookmark::try_from(PotentialBookmark::from((uri, Some(title_old), &vec![])))
+                .expect("draft bookmark should've been created");
         let start = SystemTime::now();
         let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
         let now = since_the_epoch.as_secs() as i64;
@@ -769,7 +779,7 @@ mod tests {
         .expect("bookmark should've been saved the first time");
 
         // WHEN
-        let draft_bookmark = DraftBookmark::try_from((uri, None, &vec![]))
+        let draft_bookmark = DraftBookmark::try_from(PotentialBookmark::from((uri, None, &vec![])))
             .expect("draft bookmark should've been created");
         let save_options = SaveBookmarkOptions {
             reset_missing_attributes: true,
@@ -800,8 +810,9 @@ mod tests {
         let old_tags = vec!["rust", "sqlite"];
         let uri = "https://github.com/launchbadge/sqlx";
         let title = "sqlx's github page";
-        let draft_bookmark_old = DraftBookmark::try_from((uri, Some(title), &old_tags))
-            .expect("draft bookmark should've been created");
+        let draft_bookmark_old =
+            DraftBookmark::try_from(PotentialBookmark::from((uri, Some(title), &old_tags)))
+                .expect("draft bookmark should've been created");
         let start = SystemTime::now();
         let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
         let now = since_the_epoch.as_secs() as i64;
@@ -817,8 +828,9 @@ mod tests {
         .expect("bookmark should've been saved the first time");
 
         // WHEN
-        let draft_bookmark = DraftBookmark::try_from((uri, Some(title), &vec![]))
-            .expect("draft bookmark should've been created");
+        let draft_bookmark =
+            DraftBookmark::try_from(PotentialBookmark::from((uri, Some(title), &vec![])))
+                .expect("draft bookmark should've been created");
         let save_options = SaveBookmarkOptions {
             reset_missing_attributes: false,
             reset_tags: true,
@@ -861,8 +873,9 @@ mod tests {
         let old_tags = vec!["rust", "sqlite"];
         let uri = "https://github.com/launchbadge/sqlx";
         let title = "sqlx's github page";
-        let draft_bookmark_old = DraftBookmark::try_from((uri, Some(title), &old_tags))
-            .expect("draft bookmark should've been created");
+        let draft_bookmark_old =
+            DraftBookmark::try_from(PotentialBookmark::from((uri, Some(title), &old_tags)))
+                .expect("draft bookmark should've been created");
         let start = SystemTime::now();
         let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
         let now = since_the_epoch.as_secs() as i64;
@@ -878,8 +891,9 @@ mod tests {
         .expect("bookmark should've been saved the first time");
 
         // WHEN
-        let draft_bookmark = DraftBookmark::try_from((uri, Some(title), &vec![]))
-            .expect("draft bookmark should've been created");
+        let draft_bookmark =
+            DraftBookmark::try_from(PotentialBookmark::from((uri, Some(title), &vec![])))
+                .expect("draft bookmark should've been created");
         let save_options = SaveBookmarkOptions {
             reset_missing_attributes: false,
             reset_tags: true,
@@ -923,7 +937,7 @@ mod tests {
         let draft_bookmarks = uris
             .into_iter()
             .map(|(uri, title, tags)| {
-                DraftBookmark::try_from((uri, title, &tags))
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, &tags)))
                     .expect("draft bookmarks should've been initialized")
             })
             .collect::<Vec<_>>();
@@ -968,7 +982,7 @@ mod tests {
         let draft_bookmarks_original = uris
             .into_iter()
             .map(|(uri, title, tags)| {
-                DraftBookmark::try_from((uri, title, &tags))
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, &tags)))
                     .expect("draft bookmarks should've been initialized")
             })
             .collect::<Vec<_>>();
@@ -994,7 +1008,7 @@ mod tests {
         let draft_bookmarks = updated_uris
             .into_iter()
             .map(|(uri, title, tags)| {
-                DraftBookmark::try_from((uri, title, &tags))
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, &tags)))
                     .expect("draft bookmarks should've been initialized")
             })
             .collect::<Vec<_>>();
@@ -1045,7 +1059,7 @@ mod tests {
         let draft_bookmarks_original = uris
             .into_iter()
             .map(|(uri, title, tags)| {
-                DraftBookmark::try_from((uri, title, &tags))
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, &tags)))
                     .expect("draft bookmarks should've been initialized")
             })
             .collect::<Vec<_>>();
@@ -1071,7 +1085,8 @@ mod tests {
         let draft_bookmarks = updated_uris
             .into_iter()
             .map(|uri| {
-                DraftBookmark::try_from(uri).expect("draft bookmarks should've been initialized")
+                DraftBookmark::try_from(PotentialBookmark::from((uri, None, None)))
+                    .expect("draft bookmarks should've been initialized")
             })
             .collect::<Vec<_>>();
 
@@ -1119,7 +1134,7 @@ mod tests {
         let draft_bookmarks_original = uris
             .into_iter()
             .map(|(uri, title, tags)| {
-                DraftBookmark::try_from((uri, title, &tags))
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, &tags)))
                     .expect("draft bookmarks should've been initialized")
             })
             .collect::<Vec<_>>();
@@ -1145,7 +1160,8 @@ mod tests {
         let draft_bookmarks = updated_uris
             .into_iter()
             .map(|uri| {
-                DraftBookmark::try_from(uri).expect("draft bookmarks should've been initialized")
+                DraftBookmark::try_from(PotentialBookmark::from((uri, None, None)))
+                    .expect("draft bookmarks should've been initialized")
             })
             .collect::<Vec<_>>();
 

--- a/src/persistence/delete.rs
+++ b/src/persistence/delete.rs
@@ -93,7 +93,7 @@ mod tests {
     use super::super::test_fixtures::DBPoolFixture;
     use super::super::{create_or_update_bookmark, get_num_bookmarks, get_tags};
     use super::*;
-    use crate::domain::DraftBookmark;
+    use crate::domain::{DraftBookmark, PotentialBookmark};
     use crate::persistence::SaveBookmarkOptions;
     use pretty_assertions::assert_eq;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -113,8 +113,9 @@ mod tests {
 
         for i in 1..=num_bookmarks {
             let uri = format!("https://uri-{}.com", i);
-            let draft_bookmark = DraftBookmark::try_from((uri.as_str(), None, &vec![]))
-                .expect("draft bookmark should've been created");
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri.as_str(), None, &vec![])))
+                    .expect("draft bookmark should've been created");
             println!("draft_bookmark: {}", draft_bookmark.uri());
             create_or_update_bookmark(
                 &fixture.pool,
@@ -152,7 +153,7 @@ mod tests {
         let now = since_the_epoch.as_secs() as i64;
 
         let uri = "https://uri.com";
-        let draft_bookmark = DraftBookmark::try_from((uri, None, &vec![]))
+        let draft_bookmark = DraftBookmark::try_from(PotentialBookmark::from((uri, None, &vec![])))
             .expect("draft bookmark should've been created");
         println!("draft_bookmark: {}", draft_bookmark.uri());
         create_or_update_bookmark(
@@ -190,8 +191,9 @@ mod tests {
         let now = since_the_epoch.as_secs() as i64;
 
         let uri = "https://uri.com";
-        let draft_bookmark = DraftBookmark::try_from((uri, None, &vec!["tag"]))
-            .expect("draft bookmark should've been created");
+        let draft_bookmark =
+            DraftBookmark::try_from(PotentialBookmark::from((uri, None, &vec!["tag"])))
+                .expect("draft bookmark should've been created");
         println!("draft_bookmark: {}", draft_bookmark.uri());
         create_or_update_bookmark(
             &fixture.pool,
@@ -233,8 +235,9 @@ mod tests {
         let now = since_the_epoch.as_secs() as i64;
 
         for (uri, title, tags) in uris {
-            let draft_bookmark = DraftBookmark::try_from((uri, title, &tags))
-                .expect("draft bookmark should be initialized");
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, &tags)))
+                    .expect("draft bookmark should be initialized");
             create_or_update_bookmark(
                 &fixture.pool,
                 &draft_bookmark,

--- a/src/persistence/get.rs
+++ b/src/persistence/get.rs
@@ -638,7 +638,10 @@ mod tests {
     use super::super::create_or_update_bookmark;
     use super::super::test_fixtures::DBPoolFixture;
     use super::*;
-    use crate::{domain::DraftBookmark, persistence::SaveBookmarkOptions};
+    use crate::{
+        domain::{DraftBookmark, PotentialBookmark},
+        persistence::SaveBookmarkOptions,
+    };
     use pretty_assertions::assert_eq;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -660,7 +663,7 @@ mod tests {
         let fixture = DBPoolFixture::new().await;
         let uri = "https://github.com/launchbadge/sqlx";
         let title = Some("sqlx's github page");
-        let draft_bookmark = DraftBookmark::try_from((uri, title, &Vec::new()))
+        let draft_bookmark = DraftBookmark::try_from(PotentialBookmark::from((uri, title, None)))
             .expect("draft bookmark should be initialized");
 
         let start = SystemTime::now();
@@ -707,7 +710,7 @@ mod tests {
         let fixture = DBPoolFixture::new().await;
         let uri = "https://github.com/launchbadge/sqlx";
         let title = Some("sqlx's github page");
-        let draft_bookmark = DraftBookmark::try_from((uri, title, &Vec::new()))
+        let draft_bookmark = DraftBookmark::try_from(PotentialBookmark::from((uri, title, None)))
             .expect("draft bookmark should be initialized");
         let start = SystemTime::now();
         let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
@@ -745,8 +748,9 @@ mod tests {
         ];
 
         for uri in uris {
-            let draft_bookmark = DraftBookmark::try_from((uri, None, &Vec::new()))
-                .expect("draft bookmark should be initialized");
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri, None, None)))
+                    .expect("draft bookmark should be initialized");
             let start = SystemTime::now();
             let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
             let now = since_the_epoch.as_secs() as i64;
@@ -792,8 +796,9 @@ mod tests {
         ];
 
         for (uri, title) in uris {
-            let draft_bookmark = DraftBookmark::try_from((uri, title, &Vec::new()))
-                .expect("draft bookmark should be initialized");
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, None)))
+                    .expect("draft bookmark should be initialized");
             let start = SystemTime::now();
             let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
             let now = since_the_epoch.as_secs() as i64;
@@ -847,8 +852,9 @@ mod tests {
         ];
 
         for (uri, title, tags) in uris {
-            let draft_bookmark = DraftBookmark::try_from((uri, title, &tags))
-                .expect("draft bookmark should've been initialized");
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, &tags)))
+                    .expect("draft bookmark should've been initialized");
             let start = SystemTime::now();
             let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
             let now = since_the_epoch.as_secs() as i64;
@@ -908,8 +914,9 @@ mod tests {
         ];
 
         for (uri, title, tags) in uris {
-            let draft_bookmark = DraftBookmark::try_from((uri, title, &tags))
-                .expect("draft bookmark should've been initialized");
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, &tags)))
+                    .expect("draft bookmark should've been initialized");
             let start = SystemTime::now();
             let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
             let now = since_the_epoch.as_secs() as i64;
@@ -969,8 +976,9 @@ mod tests {
         ];
 
         for (uri, title, tags) in uris {
-            let draft_bookmark = DraftBookmark::try_from((uri, title, &tags))
-                .expect("draft bookmark should be initialized");
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, &tags)))
+                    .expect("draft bookmark should be initialized");
             let start = SystemTime::now();
             let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
             let now = since_the_epoch.as_secs() as i64;
@@ -1015,8 +1023,9 @@ mod tests {
         ];
 
         for (uri, title) in uris {
-            let draft_bookmark = DraftBookmark::try_from((uri, title, &Vec::new()))
-                .expect("draft bookmark should be initialized");
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, None)))
+                    .expect("draft bookmark should be initialized");
             let start = SystemTime::now();
             let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
             let now = since_the_epoch.as_secs() as i64;
@@ -1078,8 +1087,9 @@ mod tests {
         ];
 
         for (uri, title, tags) in uris {
-            let draft_bookmark = DraftBookmark::try_from((uri, title, &tags))
-                .expect("draft bookmark should be initialized");
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, &tags)))
+                    .expect("draft bookmark should be initialized");
             let start = SystemTime::now();
             let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
             let now = since_the_epoch.as_secs() as i64;
@@ -1142,8 +1152,9 @@ mod tests {
         ];
 
         for (uri, title, tags) in uris {
-            let draft_bookmark = DraftBookmark::try_from((uri, title, &tags))
-                .expect("draft bookmark should be initialized");
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, &tags)))
+                    .expect("draft bookmark should be initialized");
             let start = SystemTime::now();
             let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
             let now = since_the_epoch.as_secs() as i64;
@@ -1187,8 +1198,9 @@ mod tests {
         ];
 
         for uri in uris {
-            let draft_bookmark = DraftBookmark::try_from((uri, None, &Vec::new()))
-                .expect("draft bookmark should be initialized");
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri, None, None)))
+                    .expect("draft bookmark should be initialized");
             let start = SystemTime::now();
             let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
             let now = since_the_epoch.as_secs() as i64;
@@ -1223,8 +1235,12 @@ mod tests {
 
         create_or_update_bookmark(
             &fixture.pool,
-            &DraftBookmark::try_from(("https://github.com/launchbadge/sqlx", None, &Vec::new()))
-                .expect("draft bookmark 1 should be initialized"),
+            &DraftBookmark::try_from(PotentialBookmark::from((
+                "https://github.com/launchbadge/sqlx",
+                None,
+                None,
+            )))
+            .expect("draft bookmark 1 should be initialized"),
             now - 200 * 60,
             SaveBookmarkOptions::default(),
         )
@@ -1233,8 +1249,12 @@ mod tests {
 
         create_or_update_bookmark(
             &fixture.pool,
-            &DraftBookmark::try_from(("https://github.com/serde-rs/serde", None, &Vec::new()))
-                .expect("draft bookmark 2 should be initialized"),
+            &DraftBookmark::try_from(PotentialBookmark::from((
+                "https://github.com/serde-rs/serde",
+                None,
+                None,
+            )))
+            .expect("draft bookmark 2 should be initialized"),
             now - 150 * 60,
             SaveBookmarkOptions::default(),
         )
@@ -1243,8 +1263,12 @@ mod tests {
 
         create_or_update_bookmark(
             &fixture.pool,
-            &DraftBookmark::try_from(("https://github.com/clap-rs/clap", None, &Vec::new()))
-                .expect("draft bookmark 3 should be initialized"),
+            &DraftBookmark::try_from(PotentialBookmark::from((
+                "https://github.com/clap-rs/clap",
+                None,
+                None,
+            )))
+            .expect("draft bookmark 3 should be initialized"),
             now - 100 * 60,
             SaveBookmarkOptions::default(),
         )
@@ -1253,8 +1277,12 @@ mod tests {
 
         create_or_update_bookmark(
             &fixture.pool,
-            &DraftBookmark::try_from(("https://crates.io/crates/anyhow", None, &Vec::new()))
-                .expect("draft bookmark 4 should be initialized"),
+            &DraftBookmark::try_from(PotentialBookmark::from((
+                "https://crates.io/crates/anyhow",
+                None,
+                None,
+            )))
+            .expect("draft bookmark 4 should be initialized"),
             now,
             SaveBookmarkOptions::default(),
         )
@@ -1315,8 +1343,9 @@ mod tests {
         let now = since_the_epoch.as_secs() as i64;
 
         for (uri, title, tags) in uris {
-            let draft_bookmark = DraftBookmark::try_from((uri, title, &tags))
-                .expect("draft bookmark should be initialized");
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, &tags)))
+                    .expect("draft bookmark should be initialized");
             create_or_update_bookmark(
                 &fixture.pool,
                 &draft_bookmark,
@@ -1381,8 +1410,9 @@ mod tests {
         let now = since_the_epoch.as_secs() as i64;
 
         for (uri, title, tags) in uris {
-            let draft_bookmark = DraftBookmark::try_from((uri, title, &tags))
-                .expect("draft bookmark should be initialized");
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, &tags)))
+                    .expect("draft bookmark should be initialized");
             create_or_update_bookmark(
                 &fixture.pool,
                 &draft_bookmark,
@@ -1423,8 +1453,9 @@ mod tests {
         let now = since_the_epoch.as_secs() as i64;
 
         for (uri, title, tags) in uris {
-            let draft_bookmark = DraftBookmark::try_from((uri, title, &tags))
-                .expect("draft bookmark should be initialized");
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, &tags)))
+                    .expect("draft bookmark should be initialized");
             create_or_update_bookmark(
                 &fixture.pool,
                 &draft_bookmark,

--- a/src/persistence/update.rs
+++ b/src/persistence/update.rs
@@ -123,7 +123,7 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;
-    use crate::domain::{DraftBookmark, Tag};
+    use crate::domain::{DraftBookmark, PotentialBookmark, Tag};
     use crate::persistence::test_fixtures::DBPoolFixture;
     use crate::persistence::{
         SaveBookmarkOptions, create_or_update_bookmark, get_bookmark_with_exact_uri, get_tags,
@@ -138,8 +138,12 @@ mod tests {
         // GIVEN
         let fixture = DBPoolFixture::new().await;
         let uri = "https://github.com/launchbadge/sqlx";
-        let draft_bookmark = DraftBookmark::try_from((uri, None, &vec!["old-tag-1", "old-tag-2"]))
-            .expect("draft bookmark should be initialized");
+        let draft_bookmark = DraftBookmark::try_from(PotentialBookmark::from((
+            uri,
+            None,
+            &vec!["old-tag-1", "old-tag-2"],
+        )))
+        .expect("draft bookmark should be initialized");
 
         let start = SystemTime::now();
         let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
@@ -189,8 +193,9 @@ mod tests {
         let now = since_the_epoch.as_secs() as i64;
 
         for (uri, title, tags) in uris {
-            let draft_bookmark = DraftBookmark::try_from((uri, title, &tags))
-                .expect("draft bookmark should be initialized");
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, &tags)))
+                    .expect("draft bookmark should be initialized");
             create_or_update_bookmark(
                 &fixture.pool,
                 &draft_bookmark,
@@ -259,8 +264,12 @@ mod tests {
         // GIVEN
         let fixture = DBPoolFixture::new().await;
         let uri = "https://github.com/launchbadge/sqlx";
-        let draft_bookmark = DraftBookmark::try_from((uri, None, &vec!["old-tag-1", "old-tag-2"]))
-            .expect("draft bookmark should be initialized");
+        let draft_bookmark = DraftBookmark::try_from(PotentialBookmark::from((
+            uri,
+            None,
+            &vec!["old-tag-1", "old-tag-2"],
+        )))
+        .expect("draft bookmark should be initialized");
 
         let start = SystemTime::now();
         let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();

--- a/tests/import_test.rs
+++ b/tests/import_test.rs
@@ -41,6 +41,27 @@ fn importing_from_an_invalid_html_file_doesnt_fail() {
 }
 
 #[test]
+fn force_importing_from_an_html_file_with_some_invalid_attrs_works() {
+    // GIVEN
+    let fixture = Fixture::new();
+    let mut cmd = fixture.command();
+    cmd.args([
+        "import",
+        "tests/static/import/valid-with-some-invalid-attributes.html",
+        "-i",
+    ]);
+
+    // WHEN
+    let output = cmd.output().expect("command should've run");
+
+    // THEN
+    output.print_stderr_if_failed(None);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("invalid utf-8 stdout");
+    assert_eq!(stdout.trim(), "imported 4 bookmarks");
+}
+
+#[test]
 fn importing_from_a_valid_json_file_works() {
     // GIVEN
     let fixture = Fixture::new();
@@ -72,6 +93,27 @@ fn importing_from_a_json_file_with_only_mandatory_details_works() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).expect("invalid utf-8 stdout");
     assert_eq!(stdout.trim(), "imported 2 bookmarks");
+}
+
+#[test]
+fn force_importing_from_a_json_file_with_some_invalid_attrs_works() {
+    // GIVEN
+    let fixture = Fixture::new();
+    let mut cmd = fixture.command();
+    cmd.args([
+        "import",
+        "tests/static/import/valid-with-some-invalid-attributes.json",
+        "-i",
+    ]);
+
+    // WHEN
+    let output = cmd.output().expect("command should've run");
+
+    // THEN
+    output.print_stderr_if_failed(None);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("invalid utf-8 stdout");
+    assert_eq!(stdout.trim(), "imported 4 bookmarks");
 }
 
 #[test]
@@ -214,6 +256,23 @@ fn importing_from_a_json_file_fails_if_missing_uri() {
     let fixture = Fixture::new();
     let mut cmd = fixture.command();
     cmd.args(["import", "tests/static/import/missing-uri.json"]);
+
+    // WHEN
+    let output = cmd.output().expect("command should've run");
+
+    // THEN
+    output.print_stdout_if_succeeded(None);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("invalid utf-8 stderr");
+    assert!(stderr.contains("missing field `uri`"));
+}
+
+#[test]
+fn importing_from_a_json_file_fails_if_missing_uri_even_when_forced() {
+    // GIVEN
+    let fixture = Fixture::new();
+    let mut cmd = fixture.command();
+    cmd.args(["import", "tests/static/import/missing-uri.json", "-i"]);
 
     // WHEN
     let output = cmd.output().expect("command should've run");

--- a/tests/save_all_test.rs
+++ b/tests/save_all_test.rs
@@ -182,6 +182,49 @@ Tags : tools
     );
 }
 
+#[test]
+fn force_saving_multiple_bookmarks_with_invalid_tags_works() {
+    // GIVEN
+    let fixture = Fixture::new();
+    let mut cmd = fixture.command();
+    cmd.args([
+        "save-all",
+        URI_ONE,
+        URI_TWO,
+        URI_THREE,
+        "--tags",
+        "tag1,invalid tag, another    invalid\t\ttag ",
+        "-i",
+    ]);
+
+    // WHEN
+    let output = cmd.output().expect("command should've run");
+
+    // THEN
+    output.print_stderr_if_failed(None);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("invalid utf-8 stdout");
+    assert_eq!(stdout.trim(), "saved 3 bookmarks");
+
+    let mut list_tags_cmd = fixture.command();
+    list_tags_cmd.args(["tags", "list"]);
+    let list_tags_output = list_tags_cmd
+        .output()
+        .expect("list tags command should've run");
+    assert!(list_tags_output.status.success());
+    let list_tags_stdout =
+        String::from_utf8(list_tags_output.stdout).expect("invalid utf-8 list_stdout");
+    assert_eq!(
+        list_tags_stdout.trim(),
+        "
+another-invalid-tag
+invalid-tag
+tag1
+"
+        .trim()
+    );
+}
+
 //------------//
 //  FAILURES  //
 //------------//

--- a/tests/save_test.rs
+++ b/tests/save_test.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::{ExpectedSuccess, Fixture};
+use common::{ExpectedFailure, ExpectedSuccess, Fixture};
 use pretty_assertions::assert_eq;
 
 const URI_ONE: &str = "https://github.com/dhth/bmm";
@@ -127,4 +127,128 @@ fn resetting_properties_on_bookmark_update_works() {
     assert!(list_output.status.success());
     let list_stdout = String::from_utf8(list_output.stdout).expect("invalid utf-8 list_stdout");
     assert!(list_stdout.contains(&format!(r#"{},,"bookmarks,cli"#, URI_ONE)));
+}
+
+#[test]
+fn force_saving_a_new_bookmark_with_a_long_title_works() {
+    // GIVEN
+    let fixture = Fixture::new();
+    let mut cmd = fixture.command();
+    let title = "a".repeat(501);
+    cmd.args(["save", URI_ONE, "--title", title.as_str(), "-i"]);
+
+    // WHEN
+    let output = cmd.output().expect("command should've run");
+
+    // THEN
+    output.print_stderr_if_failed(None);
+    assert!(output.status.success());
+
+    let mut show_cmd = fixture.command();
+    show_cmd.args(["show", URI_ONE]);
+    let show_output = show_cmd.output().expect("show command should've run");
+    assert!(show_output.status.success());
+    let list_stdout = String::from_utf8(show_output.stdout).expect("invalid utf-8 list_stdout");
+    assert_eq!(
+        list_stdout.trim(),
+        format!(
+            r#"
+Bookmark details
+---
+
+Title: {}
+URI  : {}
+Tags : <NOT SET>
+        "#,
+            "a".repeat(500),
+            URI_ONE
+        )
+        .trim()
+    );
+}
+
+#[test]
+fn force_saving_a_new_bookmark_with_invalid_tags_works() {
+    // GIVEN
+    let fixture = Fixture::new();
+    let mut cmd = fixture.command();
+    cmd.args([
+        "save",
+        URI_ONE,
+        "--tags",
+        "tag1,invalid tag, another    invalid\t\ttag ",
+        "-i",
+    ]);
+
+    // WHEN
+    let output = cmd.output().expect("command should've run");
+
+    // THEN
+    output.print_stderr_if_failed(None);
+    assert!(output.status.success());
+
+    let mut show_cmd = fixture.command();
+    show_cmd.args(["show", URI_ONE]);
+    let show_output = show_cmd.output().expect("show command should've run");
+    assert!(show_output.status.success());
+    let list_stdout = String::from_utf8(show_output.stdout).expect("invalid utf-8 list_stdout");
+    assert_eq!(
+        list_stdout.trim(),
+        format!(
+            r#"
+Bookmark details
+---
+
+Title: <NOT SET>
+URI  : {}
+Tags : another-invalid-tag,invalid-tag,tag1
+        "#,
+            URI_ONE
+        )
+        .trim()
+    );
+}
+
+//------------//
+//  FAILURES  //
+//------------//
+
+#[test]
+fn saving_a_new_bookmark_with_a_long_title_fails() {
+    // GIVEN
+    let fixture = Fixture::new();
+    let mut cmd = fixture.command();
+    let title = "a".repeat(501);
+    cmd.args(["save", URI_ONE, "--title", title.as_str()]);
+
+    // WHEN
+    let output = cmd.output().expect("command should've run");
+
+    // THEN
+    output.print_stdout_if_succeeded(None);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("invalid utf-8 list_stderr");
+    assert!(stderr.contains("title is too long"))
+}
+
+#[test]
+fn saving_a_new_bookmark_with_an_invalid_tag_fails() {
+    // GIVEN
+    let fixture = Fixture::new();
+    let mut cmd = fixture.command();
+    cmd.args([
+        "save",
+        URI_ONE,
+        "--tags",
+        "tag1,invalid tag, another    invalid\t\ttag ",
+    ]);
+
+    // WHEN
+    let output = cmd.output().expect("command should've run");
+
+    // THEN
+    output.print_stdout_if_succeeded(None);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("invalid utf-8 list_stderr");
+    assert!(stderr.contains(r#"tags ["invalid tag", " another    invalid\t\ttag "] are invalid"#))
 }

--- a/tests/static/import/valid-with-some-invalid-attributes.html
+++ b/tests/static/import/valid-with-some-invalid-attributes.html
@@ -1,0 +1,25 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<!-- This is an automatically generated file.
+     It will be read and overwritten.
+     DO NOT EDIT! -->
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<meta http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'none'; img-src data: *; object-src 'none'"></meta>
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks Menu</H1>
+
+<DL><p>
+    <DT><H3 ADD_DATE="1736450822" LAST_MODIFIED="1739920697" PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Toolbar</H3>
+    <DL><p>
+        <DT><H3 ADD_DATE="1739896938" LAST_MODIFIED="1739920670">productivity</H3>
+        <DL><p>
+            <DT><H3 ADD_DATE="1739896992" LAST_MODIFIED="1739920767">crates</H3>
+            <DL><p>
+                <DT><A HREF="https://crates.io/crates/sqlx" ADD_DATE="1739897020" LAST_MODIFIED="1739897041" ICON_URI="https://crates.io/favicon.ico" TAGS="crates,rust">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</A>
+            </DL><p>
+            <DT><A HREF="https://github.com/dhth/omm" ADD_DATE="1739920615" LAST_MODIFIED="1739920646" ICON_URI="https://github.com/fluidicon.png" TAGS="productivity,invalid tag, another invalid tag ">GitHub - dhth/omm: on-my-mind: a keyboard-driven task manager for the command line</A>
+            <DT><A HREF="https://github.com/dhth/hours" ADD_DATE="1739920661" LAST_MODIFIED="1739920670" ICON_URI="https://github.com/fluidicon.png" TAGS="productivity,tools">GitHub - dhth/hours: A no-frills time tracking toolkit for command line nerds</A>
+        </DL><p>
+        <DT><A HREF="https://github.com/dhth/bmm" ADD_DATE="1739920697" LAST_MODIFIED="1739920739" ICON_URI="https://github.com/fluidicon.png" TAGS="tools">GitHub - dhth/bmm: get to your bookmarks in a flash</A>
+    </DL><p>
+</DL>

--- a/tests/static/import/valid-with-some-invalid-attributes.json
+++ b/tests/static/import/valid-with-some-invalid-attributes.json
@@ -1,0 +1,22 @@
+[
+  {
+    "uri": "https://crates.io/crates/sqlx",
+    "title": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "tags": "crates,rust"
+  },
+  {
+    "uri": "https://github.com/dhth/omm",
+    "title": "GitHub - dhth/omm: on-my-mind: a keyboard-driven task manager for the command line",
+    "tags": "productivity, invalid tag, another invalid tag "
+  },
+  {
+    "uri": "https://github.com/dhth/hours",
+    "title": "GitHub - dhth/hours: A no-frills time tracking toolkit for command line nerds",
+    "tags": "productivity,tools"
+  },
+  {
+    "uri": "https://github.com/dhth/bmm",
+    "title": "GitHub - dhth/bmm: get to your bookmarks in a flash",
+    "tags": "tools"
+  }
+]


### PR DESCRIPTION
Allow ignoring attribute errors (eg. title being too long, or invalid tags
submitted) while saving/importing bookmarks.

Fulfils https://github.com/dhth/bmm/issues/7.
