### PR TITLE
use offline sqlx by default

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -10,7 +10,6 @@ curl -fsSL https://mise.run/bash | sh
 	"aqua:EmbarkStudios/cargo-deny" \
 	cargo-dist \
 	cargo-insta \
-	"cargo:sqlx-cli" \
 	rust \
 	shellcheck \
 	yamlfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,8 +112,8 @@ jobs:
         uses: jdx/mise-action@v4
         with:
           install_args: rust cargo:sqlx-cli
-      - name: Run SQLx online checks
-        run: mise run sqlx:online-checks
+      - name: Check SQLx query metadata
+        run: mise run sqlx:prepare-check
       - name: Run tests
         env:
           RUST_BACKTRACE: 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,8 +112,8 @@ jobs:
         uses: jdx/mise-action@v4
         with:
           install_args: rust cargo:sqlx-cli
-      - name: Set up test database
-        run: mise run test:setup
+      - name: Run SQLx online checks
+        run: mise run sqlx:online-checks
       - name: Run tests
         env:
           RUST_BACKTRACE: 0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -113,8 +113,8 @@ jobs:
         uses: jdx/mise-action@v4
         with:
           install_args: rust cargo:sqlx-cli
-      - name: Run SQLx online checks
-        run: mise run sqlx:online-checks
+      - name: Check SQLx query metadata
+        run: mise run sqlx:prepare-check
       - name: Run tests
         env:
           RUST_BACKTRACE: 0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -113,8 +113,8 @@ jobs:
         uses: jdx/mise-action@v4
         with:
           install_args: rust cargo:sqlx-cli
-      - name: Set up test database
-        run: mise run test:setup
+      - name: Run SQLx online checks
+        run: mise run sqlx:online-checks
       - name: Run tests
         env:
           RUST_BACKTRACE: 0

--- a/mise.toml
+++ b/mise.toml
@@ -12,14 +12,13 @@ shellcheck = "0.11.0"
 yamlfmt = "0.21.0"
 
 [env]
-DATABASE_URL = "sqlite://testdb/db.db"
+SQLX_OFFLINE = "true"
 
 [tasks.all]
 alias = "a"
-description = "Format, prepare the test database, lint, and test"
+description = "Format, lint, and test"
 run = [
 	{ task = "fmt" },
-	{ task = "test:setup" },
 	{ task = "lint" },
 	{ task = "test" },
 ]
@@ -82,40 +81,21 @@ description = "Run the application"
 raw_args = true
 run = "cargo run --"
 
-[tasks."sqlx:check"]
-alias = "sqlx-check"
-description = "Check SQLx query metadata"
-run = "cargo sqlx prepare --check"
-
-[tasks."sqlx:create"]
-alias = "sqlx-create"
-description = "Create the configured database"
-run = "cargo sqlx database create"
-
-[tasks."sqlx:migrate"]
-alias = "sqlx-migrate"
-description = "Run database migrations"
-run = "cargo sqlx migrate run"
-
-[tasks."sqlx:prepare"]
-alias = "sqlx-prepare"
-description = "Generate SQLx query metadata"
-run = "cargo sqlx prepare"
+[tasks."sqlx:online-checks"]
+description = "Validate SQLx query metadata against the migrated test database"
+env = { DATABASE_URL = "sqlite://testdb/db.db", SQLX_OFFLINE = "false" }
+run = [
+	"mkdir -p testdb",
+	"cargo sqlx database create",
+	"cargo sqlx migrate run",
+	"cargo sqlx prepare --check",
+]
 
 [tasks.test]
 alias = "t"
 description = "Run all tests"
 raw_args = true
 run = "cargo test"
-
-[tasks."test:setup"]
-description = "Create and validate the test database"
-run = [
-	"mkdir -p testdb",
-	{ task = "sqlx:create" },
-	{ task = "sqlx:migrate" },
-	{ task = "sqlx:check" },
-]
 
 [tasks."test:review"]
 alias = "test-review"

--- a/mise.toml
+++ b/mise.toml
@@ -81,7 +81,17 @@ description = "Run the application"
 raw_args = true
 run = "cargo run --"
 
-[tasks."sqlx:online-checks"]
+[tasks."sqlx:prepare"]
+description = "Generate SQLx query metadata against the migrated test database"
+env = { DATABASE_URL = "sqlite://testdb/db.db", SQLX_OFFLINE = "false" }
+run = [
+	"mkdir -p testdb",
+	"cargo sqlx database create",
+	"cargo sqlx migrate run",
+	"cargo sqlx prepare",
+]
+
+[tasks."sqlx:prepare-check"]
 description = "Validate SQLx query metadata against the migrated test database"
 env = { DATABASE_URL = "sqlite://testdb/db.db", SQLX_OFFLINE = "false" }
 run = [


### PR DESCRIPTION
Make SQLx offline mode the default for normal development checks while isolating live schema operations in dedicated tasks.

Remote development environments previously had to build and install `sqlx-cli` before running the standard check suite. This made provisioning slow even though the repository already commits SQLx query metadata.

Formatting, linting, building, and testing now compile against committed metadata in offline mode. `sqlx:prepare` regenerates metadata against a migrated test database, while `sqlx:prepare-check` validates it. CI runs the validation task explicitly.

This separates routine development from live schema validation while preserving offline-build coverage and protection against stale query metadata.