### PR TITLE
allow deletions via pattern matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Allow deleting bookmarks by URI patterns via `bmm delete --pattern`
+
+### Changed
+
+- Show affected bookmarks when confirming deletion
+
 ## [v0.3.1] - May 16, 2026
 
 ### Changed

--- a/src/args.rs
+++ b/src/args.rs
@@ -39,13 +39,23 @@ pub enum BmmCommand {
         ignore_attribute_errors: bool,
     },
     /// Delete bookmarks
+    #[command(after_help = r#"Examples:
+  Delete bookmarks by exact URIs:
+    bmm delete https://example.com https://example.org
+
+  Delete bookmarks matching URI patterns:
+    bmm delete --pattern example.com github.com
+
+  Delete without confirmation:
+    bmm delete --yes https://example.com
+"#)]
     Delete {
-        /// URIs to delete (matched exactly unless --pattern is used)
+        /// URIs to delete
         #[arg(value_name = "URI")]
         uris: Vec<String>,
-        /// Treat provided values as URI patterns (same matching behavior as list --uri)
-        #[arg(long = "pattern")]
-        pattern: bool,
+        /// Treat provided values as URI patterns instead of exact URIs
+        #[arg(short = 'p', long = "pattern")]
+        match_pattern: bool,
         /// Whether to skip confirmation
         #[arg(short = 'y', long = "yes")]
         skip_confirmation: bool,
@@ -243,17 +253,17 @@ impl std::fmt::Display for Args {
         let output = match &self.command {
             BmmCommand::Delete {
                 uris,
-                pattern,
+                match_pattern,
                 skip_confirmation,
             } => format!(
                 r#"
 command           : Delete bookmark(s)
 URIs              : {}
-pattern matching  : {}
+match pattern     : {}
 skip confirmation : {}
 "#,
                 uris.join(", "),
-                pattern,
+                match_pattern,
                 skip_confirmation,
             ),
             BmmCommand::List {

--- a/src/args.rs
+++ b/src/args.rs
@@ -40,9 +40,12 @@ pub enum BmmCommand {
     },
     /// Delete bookmarks
     Delete {
-        /// URIs to delete (will be matched exactly)
+        /// URIs to delete (matched exactly unless --pattern is used)
         #[arg(value_name = "URI")]
         uris: Vec<String>,
+        /// Treat provided values as URI patterns (same matching behavior as list --uri)
+        #[arg(long = "pattern")]
+        pattern: bool,
         /// Whether to skip confirmation
         #[arg(short = 'y', long = "yes")]
         skip_confirmation: bool,
@@ -240,14 +243,17 @@ impl std::fmt::Display for Args {
         let output = match &self.command {
             BmmCommand::Delete {
                 uris,
+                pattern,
                 skip_confirmation,
             } => format!(
                 r#"
 command           : Delete bookmark(s)
 URIs              : {}
+pattern matching  : {}
 skip confirmation : {}
 "#,
                 uris.join(", "),
+                pattern,
                 skip_confirmation,
             ),
             BmmCommand::List {

--- a/src/cli/delete.rs
+++ b/src/cli/delete.rs
@@ -1,5 +1,5 @@
 use crate::persistence::DBError;
-use crate::persistence::delete_bookmarks_with_uris;
+use crate::persistence::{UriMatchMode, delete_bookmarks_with_uris, get_matching_bookmark_uris};
 use sqlx::{Pool, Sqlite};
 use std::io::{Error as IOError, Write};
 
@@ -16,18 +16,35 @@ pub enum DeleteBookmarksError {
 pub async fn delete_bookmarks(
     pool: &Pool<Sqlite>,
     uris: Vec<String>,
+    pattern: bool,
     skip_confirmation: bool,
 ) -> Result<(), DeleteBookmarksError> {
     if uris.is_empty() {
         return Ok(());
     }
 
+    let match_mode = if pattern {
+        UriMatchMode::Pattern
+    } else {
+        UriMatchMode::Exact
+    };
+    let uris = get_matching_bookmark_uris(pool, &uris, match_mode).await?;
+
+    if uris.is_empty() {
+        println!("nothing got deleted");
+        return Ok(());
+    }
+
     if !skip_confirmation {
         if uris.len() == 1 {
-            println!("Deleting 1 bookmark; enter \"y\" to confirm.");
+            println!("Deleting 1 bookmark:");
         } else {
-            println!("Deleting {} bookmarks; enter \"y\" to confirm.", uris.len());
+            println!("Deleting {} bookmarks:", uris.len());
         }
+        for uri in &uris {
+            println!("{uri}");
+        }
+        println!("Enter \"y\" to confirm.");
 
         std::io::stdout()
             .flush()

--- a/src/cli/delete.rs
+++ b/src/cli/delete.rs
@@ -16,14 +16,14 @@ pub enum DeleteBookmarksError {
 pub async fn delete_bookmarks(
     pool: &Pool<Sqlite>,
     uris: Vec<String>,
-    pattern: bool,
+    match_pattern: bool,
     skip_confirmation: bool,
 ) -> Result<(), DeleteBookmarksError> {
     if uris.is_empty() {
         return Ok(());
     }
 
-    let match_mode = if pattern {
+    let match_mode = if match_pattern {
         UriMatchMode::Pattern
     } else {
         UriMatchMode::Exact
@@ -31,20 +31,20 @@ pub async fn delete_bookmarks(
     let uris = get_matching_bookmark_uris(pool, &uris, match_mode).await?;
 
     if uris.is_empty() {
-        println!("nothing got deleted");
+        println!("no bookmarks matched");
         return Ok(());
     }
 
     if !skip_confirmation {
         if uris.len() == 1 {
-            println!("Deleting 1 bookmark:");
+            println!("Will delete 1 bookmark:");
         } else {
-            println!("Deleting {} bookmarks:", uris.len());
+            println!("Will delete {} bookmarks:", uris.len());
         }
         for uri in &uris {
-            println!("{uri}");
+            println!("  - {uri}");
         }
-        println!("Enter \"y\" to confirm.");
+        println!("\nType \"y\" to confirm.");
 
         std::io::stdout()
             .flush()
@@ -56,6 +56,7 @@ pub async fn delete_bookmarks(
             .map_err(DeleteBookmarksError::CouldntReadUserInput)?;
 
         if input.trim() != "y" {
+            println!("cancelled");
             return Ok(());
         }
     }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -38,10 +38,10 @@ pub async fn handle(args: Args) -> Result<(), AppError> {
     match args.command {
         BmmCommand::Delete {
             uris,
-            pattern,
+            match_pattern,
             skip_confirmation,
         } => {
-            delete_bookmarks(&pool, uris, pattern, skip_confirmation).await?;
+            delete_bookmarks(&pool, uris, match_pattern, skip_confirmation).await?;
         }
 
         BmmCommand::Import {

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -38,9 +38,10 @@ pub async fn handle(args: Args) -> Result<(), AppError> {
     match args.command {
         BmmCommand::Delete {
             uris,
+            pattern,
             skip_confirmation,
         } => {
-            delete_bookmarks(&pool, uris, skip_confirmation).await?;
+            delete_bookmarks(&pool, uris, pattern, skip_confirmation).await?;
         }
 
         BmmCommand::Import {

--- a/src/persistence/delete.rs
+++ b/src/persistence/delete.rs
@@ -1,6 +1,8 @@
 use super::DBError;
 use sqlx::{Pool, Sqlite};
 
+const DELETE_BATCH_SIZE: usize = 999;
+
 pub async fn delete_bookmarks_with_uris(
     pool: &Pool<Sqlite>,
     uris: &[String],
@@ -10,7 +12,9 @@ pub async fn delete_bookmarks_with_uris(
         .await
         .map_err(DBError::CouldntBeginTransaction)?;
 
-    let rows_affected = {
+    let mut rows_affected = 0;
+
+    for uri_chunk in uris.chunks(DELETE_BATCH_SIZE) {
         let query = format!(
             r#"
 DELETE FROM
@@ -25,11 +29,15 @@ WHERE
             uri IN ({})
     )
 "#,
-            uris.iter().map(|_| "?").collect::<Vec<&str>>().join(", ")
+            uri_chunk
+                .iter()
+                .map(|_| "?")
+                .collect::<Vec<&str>>()
+                .join(", ")
         );
 
         let mut query_builder = sqlx::query::<_>(&query);
-        for uri in uris {
+        for uri in uri_chunk {
             query_builder = query_builder.bind(uri.as_str());
         }
 
@@ -38,8 +46,11 @@ WHERE
             .await
             .map_err(|e| DBError::CouldntExecuteQuery("delete bookmarks with uris".into(), e))?;
 
-        sqlx::query!(
-            "
+        rows_affected += result.rows_affected();
+    }
+
+    sqlx::query!(
+        "
 DELETE FROM
     tags
 WHERE
@@ -50,13 +61,10 @@ WHERE
             bookmark_tags
     )
 ",
-        )
-        .execute(&mut *tx)
-        .await
-        .map_err(|e| DBError::CouldntExecuteQuery("clean up unused tags".into(), e))?;
-
-        result.rows_affected()
-    };
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| DBError::CouldntExecuteQuery("clean up unused tags".into(), e))?;
 
     tx.commit()
         .await
@@ -91,7 +99,10 @@ WHERE
 #[cfg(test)]
 mod tests {
     use super::super::test_fixtures::DBPoolFixture;
-    use super::super::{create_or_update_bookmark, get_num_bookmarks, get_tags};
+    use super::super::{
+        create_or_update_bookmark, create_or_update_bookmarks, get_all_bookmarks,
+        get_num_bookmarks, get_tags,
+    };
     use super::*;
     use crate::domain::{DraftBookmark, PotentialBookmark};
     use crate::persistence::SaveBookmarkOptions;
@@ -217,6 +228,86 @@ mod tests {
             .await
             .expect("tags should've been fetched");
         assert_yaml_snapshot!(tags_in_db, @"[]");
+    }
+
+    #[tokio::test]
+    async fn deleting_more_uris_than_the_batch_size_works() {
+        // GIVEN
+        let fx = DBPoolFixture::new().await;
+        let start = SystemTime::now();
+        let since_the_epoch = start
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should've been after the Unix epoch");
+        let now = since_the_epoch.as_secs() as i64;
+        let num_bookmarks_to_delete = DELETE_BATCH_SIZE * 2 + 1;
+        let mut uris_to_delete = Vec::with_capacity(num_bookmarks_to_delete);
+        let mut draft_bookmarks = Vec::with_capacity(num_bookmarks_to_delete + 2);
+
+        for i in 0..num_bookmarks_to_delete {
+            let uri = format!("https://uri-{i}.com");
+            let tags = if i % DELETE_BATCH_SIZE == 0 {
+                vec!["deleted-only", "shared"]
+            } else {
+                vec![]
+            };
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri.as_str(), None, &tags)))
+                    .expect("draft bookmark should've been created");
+            draft_bookmarks.push(draft_bookmark);
+            uris_to_delete.push(uri);
+        }
+
+        for (uri, title, tags) in [
+            (
+                "https://retained-one.com",
+                Some("retained bookmark"),
+                vec!["retained-only", "shared"],
+            ),
+            ("https://retained-two.com", None, vec![]),
+        ] {
+            let draft_bookmark =
+                DraftBookmark::try_from(PotentialBookmark::from((uri, title, &tags)))
+                    .expect("draft bookmark should've been created");
+            draft_bookmarks.push(draft_bookmark);
+        }
+
+        create_or_update_bookmarks(
+            &fx.pool,
+            &draft_bookmarks,
+            now,
+            SaveBookmarkOptions::default(),
+        )
+        .await
+        .expect("bookmarks should've been saved in db");
+
+        // WHEN
+        let rows_affected = delete_bookmarks_with_uris(&fx.pool, &uris_to_delete)
+            .await
+            .expect("bookmarks should've been deleted");
+
+        // THEN
+        assert_eq!(rows_affected, num_bookmarks_to_delete as u64);
+
+        let mut bookmarks = get_all_bookmarks(&fx.pool)
+            .await
+            .expect("bookmarks should've been fetched");
+        bookmarks.sort_by(|a, b| a.uri.cmp(&b.uri));
+        assert_yaml_snapshot!(bookmarks, @r#"
+        - uri: "https://retained-one.com"
+          title: retained bookmark
+          tags: "retained-only,shared"
+        - uri: "https://retained-two.com"
+          title: ~
+          tags: ~
+        "#);
+
+        let tags_in_db = get_tags(&fx.pool)
+            .await
+            .expect("tags should've been fetched");
+        assert_yaml_snapshot!(tags_in_db, @r"
+        - retained-only
+        - shared
+        ");
     }
 
     #[tokio::test]

--- a/src/persistence/delete.rs
+++ b/src/persistence/delete.rs
@@ -3,7 +3,7 @@ use sqlx::{Pool, Sqlite};
 
 pub async fn delete_bookmarks_with_uris(
     pool: &Pool<Sqlite>,
-    uris: &Vec<String>,
+    uris: &[String],
 ) -> Result<u64, DBError> {
     let mut tx = pool
         .begin()

--- a/src/persistence/get.rs
+++ b/src/persistence/get.rs
@@ -1,6 +1,6 @@
 use super::DBError;
 use crate::domain::{SavedBookmark, TagStats};
-use sqlx::{Pool, Sqlite};
+use sqlx::{Pool, QueryBuilder, Sqlite};
 
 const SEARCH_TERMS_UPPER_LIMIT: usize = 10;
 
@@ -72,6 +72,59 @@ impl TryFrom<&Vec<String>> for SearchTerms {
             terms.into_iter().map(|t| t.to_string()).collect::<Vec<_>>(),
         ))
     }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum UriMatchMode {
+    Exact,
+    Pattern,
+}
+
+pub async fn get_matching_bookmark_uris(
+    pool: &Pool<Sqlite>,
+    values: &[String],
+    mode: UriMatchMode,
+) -> Result<Vec<String>, DBError> {
+    if values.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut query_builder = QueryBuilder::<Sqlite>::new(
+        r#"
+SELECT
+    uri
+FROM
+    bookmarks
+WHERE
+    "#,
+    );
+
+    match mode {
+        UriMatchMode::Exact => {
+            query_builder.push("uri IN (");
+            let mut values_builder = query_builder.separated(", ");
+            for value in values {
+                values_builder.push_bind(value);
+            }
+            values_builder.push_unseparated(")");
+        }
+        UriMatchMode::Pattern => {
+            let mut patterns_builder = query_builder.separated(" OR ");
+            for value in values {
+                patterns_builder
+                    .push("uri LIKE ")
+                    .push_bind_unseparated(format!("%{value}%"));
+            }
+        }
+    }
+
+    query_builder.push(" ORDER BY uri");
+
+    query_builder
+        .build_query_scalar::<String>()
+        .fetch_all(pool)
+        .await
+        .map_err(|e| DBError::CouldntExecuteQuery("fetch matching bookmark uris".into(), e))
 }
 
 pub async fn get_bookmark_with_exact_uri(
@@ -695,6 +748,114 @@ mod tests {
                 .await
                 .expect("bookmark should be saved in db");
         }
+    }
+
+    #[tokio::test]
+    async fn getting_matching_bookmark_uris_exactly_returns_existing_values() {
+        // GIVEN
+        let fx = DBPoolFixture::new().await;
+        save_test_bookmarks(&fx.pool).await;
+        let values = vec![
+            "https://github.com/serde-rs/serde".to_string(),
+            "https://does-not-exist.com".to_string(),
+            "https://github.com/launchbadge/sqlx".to_string(),
+            "https://github.com/serde-rs/serde".to_string(),
+        ];
+
+        // WHEN
+        let uris = get_matching_bookmark_uris(&fx.pool, &values, UriMatchMode::Exact)
+            .await
+            .expect("matching bookmark uris should've been fetched");
+
+        // THEN
+        assert_yaml_snapshot!(uris, @r#"
+        - "https://github.com/launchbadge/sqlx"
+        - "https://github.com/serde-rs/serde"
+        "#);
+    }
+
+    #[tokio::test]
+    async fn getting_matching_bookmark_uris_by_pattern_uses_union_semantics() {
+        // GIVEN
+        let fx = DBPoolFixture::new().await;
+        save_test_bookmarks(&fx.pool).await;
+        let values = vec!["github.com".to_string(), "serde".to_string()];
+
+        // WHEN
+        let uris = get_matching_bookmark_uris(&fx.pool, &values, UriMatchMode::Pattern)
+            .await
+            .expect("matching bookmark uris should've been fetched");
+
+        // THEN
+        assert_yaml_snapshot!(uris, @r#"
+        - "https://github.com/clap-rs/clap"
+        - "https://github.com/launchbadge/sqlx"
+        - "https://github.com/serde-rs/serde"
+        "#);
+    }
+
+    #[tokio::test]
+    async fn getting_matching_bookmark_uris_returns_nothing_when_no_values_match() {
+        // GIVEN
+        let fx = DBPoolFixture::new().await;
+        save_test_bookmarks(&fx.pool).await;
+        let values = vec!["does-not-exist".to_string()];
+
+        // WHEN
+        let exact_uris = get_matching_bookmark_uris(&fx.pool, &values, UriMatchMode::Exact)
+            .await
+            .expect("matching bookmark uris should've been fetched");
+        let pattern_uris = get_matching_bookmark_uris(&fx.pool, &values, UriMatchMode::Pattern)
+            .await
+            .expect("matching bookmark uris should've been fetched");
+
+        // THEN
+        assert!(exact_uris.is_empty());
+        assert!(pattern_uris.is_empty());
+    }
+
+    #[tokio::test]
+    async fn getting_matching_bookmark_uris_returns_nothing_for_empty_values() {
+        // GIVEN
+        let fx = DBPoolFixture::new().await;
+        save_test_bookmarks(&fx.pool).await;
+
+        // WHEN
+        let exact_uris = get_matching_bookmark_uris(&fx.pool, &[], UriMatchMode::Exact)
+            .await
+            .expect("matching bookmark uris should've been fetched");
+        let pattern_uris = get_matching_bookmark_uris(&fx.pool, &[], UriMatchMode::Pattern)
+            .await
+            .expect("matching bookmark uris should've been fetched");
+
+        // THEN
+        assert!(exact_uris.is_empty());
+        assert!(pattern_uris.is_empty());
+    }
+
+    #[tokio::test]
+    async fn getting_matching_bookmark_uris_by_pattern_has_no_result_limit() {
+        // GIVEN
+        let fx = DBPoolFixture::new().await;
+        for index in 0..501 {
+            let uri = format!("https://unlimited-{index:03}.example.com");
+            sqlx::query(
+                "INSERT INTO bookmarks (uri, title, created_at, updated_at) VALUES (?, NULL, 0, 0)",
+            )
+            .bind(uri)
+            .execute(&fx.pool)
+            .await
+            .expect("bookmark should've been saved in db");
+        }
+
+        // WHEN
+        let uris =
+            get_matching_bookmark_uris(&fx.pool, &["unlimited".to_string()], UriMatchMode::Pattern)
+                .await
+                .expect("matching bookmark uris should've been fetched");
+
+        // THEN
+        assert_eq!(uris.len(), 501);
     }
 
     #[tokio::test]

--- a/src/persistence/get.rs
+++ b/src/persistence/get.rs
@@ -834,31 +834,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn getting_matching_bookmark_uris_by_pattern_has_no_result_limit() {
-        // GIVEN
-        let fx = DBPoolFixture::new().await;
-        for index in 0..501 {
-            let uri = format!("https://unlimited-{index:03}.example.com");
-            sqlx::query(
-                "INSERT INTO bookmarks (uri, title, created_at, updated_at) VALUES (?, NULL, 0, 0)",
-            )
-            .bind(uri)
-            .execute(&fx.pool)
-            .await
-            .expect("bookmark should've been saved in db");
-        }
-
-        // WHEN
-        let uris =
-            get_matching_bookmark_uris(&fx.pool, &["unlimited".to_string()], UriMatchMode::Pattern)
-                .await
-                .expect("matching bookmark uris should've been fetched");
-
-        // THEN
-        assert_eq!(uris.len(), 501);
-    }
-
-    #[tokio::test]
     async fn get_bookmark_with_uri_returns_none_if_bookmark_doesnt_exist() {
         // GIVEN
         let fx = DBPoolFixture::new().await;

--- a/tests/delete_test.rs
+++ b/tests/delete_test.rs
@@ -12,6 +12,46 @@ const URI_THREE: &str = "https://github.com/dhth/hours";
 //-------------//
 
 #[test]
+fn shows_help() {
+    // GIVEN
+    let fx = Fixture::new();
+    let mut cmd = fx.cmd(["delete", "--help"]);
+
+    // WHEN
+    // THEN
+    assert_cmd_snapshot!(cmd, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Delete bookmarks
+
+    Usage: bmm delete [OPTIONS] [URI]...
+
+    Arguments:
+      [URI]...  URIs to delete
+
+    Options:
+      -p, --pattern           Treat provided values as URI patterns instead of exact URIs
+      -y, --yes               Whether to skip confirmation
+          --db-path <STRING>  Override bmm's database location (default: <DATA_DIR>/bmm/bmm.db)
+          --debug             Output debug information without doing anything
+      -h, --help              Print help
+
+    Examples:
+      Delete bookmarks by exact URIs:
+        bmm delete https://example.com https://example.org
+
+      Delete bookmarks matching URI patterns:
+        bmm delete --pattern example.com github.com
+
+      Delete without confirmation:
+        bmm delete --yes https://example.com
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn deleting_multiple_bookmarks_works() {
     // GIVEN
     let fx = Fixture::new();
@@ -29,7 +69,7 @@ fn deleting_multiple_bookmarks_works() {
 
     // WHEN
     // THEN
-    assert_cmd_snapshot!(cmd, @r"
+    assert_cmd_snapshot!(cmd, @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -67,18 +107,18 @@ fn deleting_shouldnt_fail_if_bookmarks_dont_exist() {
 
     // WHEN
     // THEN
-    assert_cmd_snapshot!(cmd, @r"
+    assert_cmd_snapshot!(cmd, @"
     success: true
     exit_code: 0
     ----- stdout -----
-    nothing got deleted
+    no bookmarks matched
 
     ----- stderr -----
     ");
 }
 
 #[test]
-fn deleting_bookmarks_by_multiple_patterns_works_without_confirmation() {
+fn deleting_bookmarks_by_multiple_patterns_works() {
     // GIVEN
     let fx = Fixture::new();
     let mut save_cmd = fx.cmd(["save-all", URI_ONE, URI_TWO, URI_THREE]);
@@ -95,7 +135,7 @@ fn deleting_bookmarks_by_multiple_patterns_works_without_confirmation() {
 
     // WHEN
     // THEN
-    assert_cmd_snapshot!(cmd, @r"
+    assert_cmd_snapshot!(cmd, @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -116,7 +156,7 @@ fn deleting_bookmarks_by_multiple_patterns_works_without_confirmation() {
 }
 
 #[test]
-fn confirming_exact_deletion_deletes_resolved_bookmarks() {
+fn deleting_bookmarks_by_exact_match_works() {
     // GIVEN
     let fx = Fixture::new();
     let mut save_cmd = fx.cmd(["save-all", URI_ONE, URI_TWO]);
@@ -129,21 +169,18 @@ fn confirming_exact_deletion_deletes_resolved_bookmarks() {
     ----- stderr -----
     ");
 
-    let mut cmd = fx.cmd(["delete", URI_ONE, "https://nonexistent-uri.com"]);
+    let mut cmd = fx.cmd(["delete", "--yes", URI_ONE, "https://nonexistent-uri.com"]);
 
     // WHEN
     // THEN
-    assert_cmd_snapshot!(cmd.pass_stdin("y\n"), @r#"
+    assert_cmd_snapshot!(cmd.pass_stdin("y\n"), @"
     success: true
     exit_code: 0
     ----- stdout -----
-    Deleting 1 bookmark:
-    https://github.com/dhth/bmm
-    Enter "y" to confirm.
     deleted 1 bookmark
 
     ----- stderr -----
-    "#);
+    ");
 
     let mut list_cmd = fx.cmd(["list"]);
     assert_cmd_snapshot!(list_cmd, @r"
@@ -157,7 +194,50 @@ fn confirming_exact_deletion_deletes_resolved_bookmarks() {
 }
 
 #[test]
-fn declining_pattern_deletion_keeps_resolved_bookmarks() {
+fn deleting_bookmarks_asks_for_confirmation_by_default() {
+    // GIVEN
+    let fx = Fixture::new();
+    let mut save_cmd = fx.cmd(["save-all", URI_ONE, URI_TWO, URI_THREE]);
+    assert_cmd_snapshot!(save_cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    saved 3 bookmarks
+
+    ----- stderr -----
+    ");
+
+    let mut cmd = fx.cmd(["delete", "--pattern", "bmm", "dhth/o"]);
+
+    // WHEN
+    // THEN
+    assert_cmd_snapshot!(cmd.pass_stdin("y\n"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Will delete 2 bookmarks:
+      - https://github.com/dhth/bmm
+      - https://github.com/dhth/omm
+
+    Type "y" to confirm.
+    deleted 2 bookmarks
+
+    ----- stderr -----
+    "#);
+
+    let mut list_cmd = fx.cmd(["list"]);
+    assert_cmd_snapshot!(list_cmd, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    https://github.com/dhth/hours
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn declining_deletion_keeps_resolved_bookmarks() {
     // GIVEN
     let fx = Fixture::new();
     let mut save_cmd = fx.cmd(["save-all", URI_ONE, URI_TWO, URI_THREE]);
@@ -178,11 +258,13 @@ fn declining_pattern_deletion_keeps_resolved_bookmarks() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Deleting 3 bookmarks:
-    https://github.com/dhth/bmm
-    https://github.com/dhth/hours
-    https://github.com/dhth/omm
-    Enter "y" to confirm.
+    Will delete 3 bookmarks:
+      - https://github.com/dhth/bmm
+      - https://github.com/dhth/hours
+      - https://github.com/dhth/omm
+
+    Type "y" to confirm.
+    cancelled
 
     ----- stderr -----
     "#);
@@ -222,9 +304,11 @@ fn input_other_than_y_does_not_confirm_deletion() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Deleting 1 bookmark:
-    https://github.com/dhth/bmm
-    Enter "y" to confirm.
+    Will delete 1 bookmark:
+      - https://github.com/dhth/bmm
+
+    Type "y" to confirm.
+    cancelled
 
     ----- stderr -----
     "#);

--- a/tests/delete_test.rs
+++ b/tests/delete_test.rs
@@ -173,7 +173,7 @@ fn deleting_bookmarks_by_exact_match_works() {
 
     // WHEN
     // THEN
-    assert_cmd_snapshot!(cmd.pass_stdin("y\n"), @"
+    assert_cmd_snapshot!(cmd, @"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/tests/delete_test.rs
+++ b/tests/delete_test.rs
@@ -63,7 +63,7 @@ fn deleting_shouldnt_fail_if_bookmarks_dont_exist() {
     ----- stderr -----
     ");
 
-    let mut cmd = fx.cmd(["delete", "--yes", "https://nonexistent-uri.com"]);
+    let mut cmd = fx.cmd(["delete", "https://nonexistent-uri.com"]);
 
     // WHEN
     // THEN
@@ -72,6 +72,169 @@ fn deleting_shouldnt_fail_if_bookmarks_dont_exist() {
     exit_code: 0
     ----- stdout -----
     nothing got deleted
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn deleting_bookmarks_by_multiple_patterns_works_without_confirmation() {
+    // GIVEN
+    let fx = Fixture::new();
+    let mut save_cmd = fx.cmd(["save-all", URI_ONE, URI_TWO, URI_THREE]);
+    assert_cmd_snapshot!(save_cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    saved 3 bookmarks
+
+    ----- stderr -----
+    ");
+
+    let mut cmd = fx.cmd(["delete", "--yes", "--pattern", "bmm", "dhth/o"]);
+
+    // WHEN
+    // THEN
+    assert_cmd_snapshot!(cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    deleted 2 bookmarks
+
+    ----- stderr -----
+    ");
+
+    let mut list_cmd = fx.cmd(["list"]);
+    assert_cmd_snapshot!(list_cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    https://github.com/dhth/hours
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn confirming_exact_deletion_deletes_resolved_bookmarks() {
+    // GIVEN
+    let fx = Fixture::new();
+    let mut save_cmd = fx.cmd(["save-all", URI_ONE, URI_TWO]);
+    assert_cmd_snapshot!(save_cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    saved 2 bookmarks
+
+    ----- stderr -----
+    ");
+
+    let mut cmd = fx.cmd(["delete", URI_ONE, "https://nonexistent-uri.com"]);
+
+    // WHEN
+    // THEN
+    assert_cmd_snapshot!(cmd.pass_stdin("y\n"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Deleting 1 bookmark:
+    https://github.com/dhth/bmm
+    Enter "y" to confirm.
+    deleted 1 bookmark
+
+    ----- stderr -----
+    "#);
+
+    let mut list_cmd = fx.cmd(["list"]);
+    assert_cmd_snapshot!(list_cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    https://github.com/dhth/omm
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn declining_pattern_deletion_keeps_resolved_bookmarks() {
+    // GIVEN
+    let fx = Fixture::new();
+    let mut save_cmd = fx.cmd(["save-all", URI_ONE, URI_TWO, URI_THREE]);
+    assert_cmd_snapshot!(save_cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    saved 3 bookmarks
+
+    ----- stderr -----
+    ");
+
+    let mut cmd = fx.cmd(["delete", "--pattern", "dhth"]);
+
+    // WHEN
+    // THEN
+    assert_cmd_snapshot!(cmd.pass_stdin("n\n"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Deleting 3 bookmarks:
+    https://github.com/dhth/bmm
+    https://github.com/dhth/hours
+    https://github.com/dhth/omm
+    Enter "y" to confirm.
+
+    ----- stderr -----
+    "#);
+
+    let mut list_cmd = fx.cmd(["list"]);
+    assert_cmd_snapshot!(list_cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    https://github.com/dhth/bmm
+    https://github.com/dhth/omm
+    https://github.com/dhth/hours
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn input_other_than_y_does_not_confirm_deletion() {
+    // GIVEN
+    let fx = Fixture::new();
+    let mut save_cmd = fx.cmd(["save-all", URI_ONE]);
+    assert_cmd_snapshot!(save_cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    saved 1 bookmark
+
+    ----- stderr -----
+    ");
+
+    let mut cmd = fx.cmd(["delete", URI_ONE]);
+
+    // WHEN
+    // THEN
+    assert_cmd_snapshot!(cmd.pass_stdin("yes\n"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Deleting 1 bookmark:
+    https://github.com/dhth/bmm
+    Enter "y" to confirm.
+
+    ----- stderr -----
+    "#);
+
+    let mut list_cmd = fx.cmd(["list"]);
+    assert_cmd_snapshot!(list_cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    https://github.com/dhth/bmm
 
     ----- stderr -----
     ");


### PR DESCRIPTION
Add a `--pattern` flag to `bmm delete` for deleting bookmarks whose URIs match one or more patterns. Exact URI matching remains the default to keep deletion predictable and safe.

Resolve the supplied values against stored bookmarks. In exact mode, this filters out URIs that do not exist; in pattern mode, it expands patterns into concrete stored URIs. Show the resulting bookmarks during confirmation so users can review what will actually be deleted. Continue to omit the confirmation prompt when `--yes` is used.

Pass only the resolved URIs to the destructive operation, keeping the final deletion exact. Delete large resolved sets in transactional batches instead of constructing a single unbounded query, while preserving all-or-nothing behavior.

Fixes https://github.com/dhth/bmm/issues/142.